### PR TITLE
Initialized _tls attribute in _ana_setstate for FullFrontend class.

### DIFF
--- a/claripy/frontends/full_frontend.py
+++ b/claripy/frontends/full_frontend.py
@@ -26,7 +26,8 @@ class FullFrontend(ConstrainedFrontend):
     def _ana_setstate(self, s):
         backend_name, self.timeout, base_state = s
         self._solver_backend = backends._backends_by_type[backend_name]
-        self._tls = None
+        #self._tls = None
+        self._tls = threading.local()
         self._to_add = [ ]
         ConstrainedFrontend._ana_setstate(self, base_state)
 


### PR DESCRIPTION
The _tls attribute was set to None, which prevented loading a pickled Path object. Initialized based __init__. 