### PR TITLE
Fix a bug caused by http://bugs.python.org/issue8259

### DIFF
--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -1,4 +1,3 @@
-import sys
 import functools
 from .errors import ClaripyOperationError, ClaripyTypeError
 from .backend_object import BackendObject
@@ -162,14 +161,18 @@ class BVV(BackendObject):
     @normalize_types
     @compare_bits
     def __lshift__(self, o):
-        shift = min(o.signed, sys.maxsize) # See http://bugs.python.org/issue8259
-        return BVV(self.value << shift, self.bits)
+        if o.signed < self.bits:
+            return BVV(self.value << o.signed, self.bits)
+        else:
+            return BVV(0, self.bits)
 
     @normalize_types
     @compare_bits
     def __rshift__(self, o):
-        shift = min(o.signed, sys.maxsize) # See http://bugs.python.org/issue8259
-        return BVV(self.signed >> shift, self.bits)
+        if o.signed < self.bits:
+            return BVV(self.value >> o.signed, self.bits)
+        else:
+            return BVV(0, self.bits)
 
     def __invert__(self):
         return BVV(self.value ^ self.mod-1, self.bits)

--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -1,3 +1,4 @@
+import sys
 import functools
 from .errors import ClaripyOperationError, ClaripyTypeError
 from .backend_object import BackendObject

--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -161,12 +161,14 @@ class BVV(BackendObject):
     @normalize_types
     @compare_bits
     def __lshift__(self, o):
-        return BVV(self.value << o.signed, self.bits)
+        shift = min(o.signed, sys.maxsize) # See http://bugs.python.org/issue8259
+        return BVV(self.value << shift, self.bits)
 
     @normalize_types
     @compare_bits
     def __rshift__(self, o):
-        return BVV(self.signed >> o.signed, self.bits)
+        shift = min(o.signed, sys.maxsize) # See http://bugs.python.org/issue8259
+        return BVV(self.signed >> shift, self.bits)
 
     def __invert__(self):
         return BVV(self.value ^ self.mod-1, self.bits)


### PR DESCRIPTION
I am shifting with BVV of size 256, and I encountered overflows because of that python2 specificity.