### PR TITLE
Fix: Make sure replacement cache is always used.

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -574,9 +574,13 @@ class Base(ana.Storable):
 
             hash_key = self.cache_key
 
-            if hash_key in replacements:
+            try:
                 r = replacements[hash_key]
-            elif not self.variables.issuperset(variable_set):
+                return r
+            except KeyError:
+                pass
+
+            if not self.variables.issuperset(variable_set):
                 r = self
             elif leaf_operation is not None and self.op in operations.leaf_operations:
                 r = leaf_operation(self)

--- a/claripy/frontends/replacement_frontend.py
+++ b/claripy/frontends/replacement_frontend.py
@@ -82,9 +82,10 @@ class ReplacementFrontend(ConstrainedFrontend):
         if not isinstance(old, Base):
             return old
 
-        if old.cache_key in self._replacement_cache:
+        try:
             return self._replacement_cache[old.cache_key]
-        else:
+        except KeyError:
+            # not found in the cache
             new = old.replace_dict(self._replacement_cache)
             if new is not old:
                 self._replacement_cache[old.cache_key] = new


### PR DESCRIPTION
`key in weakref.WeakKeyDictionary` sometimes returns False, which is why
the replacement cache was sometimes not enabled before. Changing it to
`try ... except KeyError ...` solves this issue.