### PR TITLE
Replacements dict is now copied on state copy

### DIFF
--- a/claripy/frontends/replacement_frontend.py
+++ b/claripy/frontends/replacement_frontend.py
@@ -43,8 +43,8 @@ class ReplacementFrontend(ConstrainedFrontend):
         if self._validation_frontend is not None:
             self._validation_frontend._copy(c._validation_frontend)
 
-        c._replacements = self._replacements
-        c._replacement_cache = self._replacement_cache
+        c._replacements = self._replacements.copy()
+        c._replacement_cache = self._replacement_cache.copy()
 
     #
     # Replacements


### PR DESCRIPTION
Before it was passed by reference which would cause problems when copying states and modifying the replacements