### PR TITLE
store string instead of integer for z3 ast hash

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -324,7 +324,7 @@ class BackendZ3(Backend):
         z3_hash = z3.Z3_get_ast_hash(ctx, ast)
         z3_ast_ref = ast.value # this seems to be the memory address
         z3_sort = z3.Z3_get_sort(ctx, ast).value
-        return hash("%d_%d_%d" % (z3_hash, z3_sort, z3_ast_ref))
+        return "%d_%d_%d" % (z3_hash, z3_sort, z3_ast_ref)
 
     def _abstract_internal(self, ctx, ast, split_on=None):
         h = self._z3_ast_hash(ctx, ast)


### PR DESCRIPTION
This solves the issue I was complaining about in slack.

For the binary that I'm working on, which I can't share, and is also probably malware, this changes angr's behavior from "crash and burn with a z3 exception after about 2000 blocks" to "run out of memory after about 8000 blocks". I suspect that this binary has logic which detects if it's being emulated and tries to fuck up its emulator, like what we did in cgc.