### PR TITLE
ite_excaveted triggered  a bug in normalize_address_type

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -817,7 +817,7 @@ class Base(ana.Storable):
         return old_true.__class__(old_true.op, new_args, length=self.length)
 
     def _excavate_ite(self):
-        if self.op in { 'BVS', 'I', 'BVV' }:
+        if self.op in { 'BVS', 'I', 'BVV' } or self.annotations:
             return self
 
         excavated_args = [ (a.ite_excavated if isinstance(a, Base) else a) for a in self.args ]


### PR DESCRIPTION
when the address expression was a ite, the added annotation in _normalize_address_type (abstract_memory.py) was removed by the ite_excavated property, causing a bug during CFG construction. 