### PR TITLE
Fix bitwise xor simplifier

### DIFF
--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -390,7 +390,7 @@ def boolean_or_simplifier(*args):
 
     return _flatten_simplifier('Or', _flattening_filter, *args)
 
-def _flatten_simplifier(op_name, filter_func, *args):
+def _flatten_simplifier(op_name, filter_func, *args, **kwargs):
     if not any(isinstance(a, ast.Base) and a.op == op_name for a in args):
         return
 
@@ -402,6 +402,8 @@ def _flatten_simplifier(op_name, filter_func, *args):
         (a.args if isinstance(a, ast.Base) and a.op == op_name else (a,)) for a in args
     ))
     if filter_func: new_args = filter_func(new_args)
+    if not new_args and kwargs.has_key('initial_value'):
+        return kwargs['initial_value']
     return next(a for a in args if isinstance(a, ast.Base)).make_like(op_name, new_args)
 
 def bitwise_add_simplifier(a, b):
@@ -436,7 +438,7 @@ def bitwise_xor_simplifier(a, b):
         unique_args = set(k for k in ctr if ctr[k] % 2 != 0)
         return tuple([ arg for arg in args if arg in unique_args ])
 
-    return _flatten_simplifier('__xor__', _flattening_filter, a, b)
+    return _flatten_simplifier('__xor__', _flattening_filter, a, b, initial_value=ast.all_operations.BVV(0, a.size()))
 
 def bitwise_or_simplifier(a, b):
     if a is ast.all_operations.BVV(0, a.size()):


### PR DESCRIPTION
# Fix bitwise xor simplifier
Filtering out all \_\_xor__ args leads to \_\_xor__ over an empty tuple which is undefined without an initial value, so it is followed by TypeError('reduce() of empty sequence with no initial value').
_flatten_simplifier is now provided with corresponding initial value.