### PR TITLE
Reverse ite cases

### DIFF
--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -159,13 +159,14 @@ def ite_cases(cases, default):
     return sofar
 
 def reverse_ite_cases(ast):
-    if ast.op == 'If':
-        for c, a in reverse_ite_cases(ast.args[1]):
-            yield And(c, ast.args[0]), a
-        for c, a in reverse_ite_cases(ast.args[2]):
-            yield And(c, Not(ast.args[0])), a
-    else:
-        yield true, ast
+    queue = [(true, ast)]
+    while queue:
+        condition, ast = queue.pop(0)
+        if ast.op == 'If':
+            queue.append((And(condition, ast.args[0]), ast.args[1]))
+            queue.append((And(condition, Not(ast.args[0])), ast.args[2]))
+        else:
+            yield condition, ast
 
 def constraint_to_si(expr):
     """

--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -158,6 +158,15 @@ def ite_cases(cases, default):
         sofar = If(c, v, sofar)
     return sofar
 
+def reverse_ite_cases(ast):
+    if ast.op == 'If':
+        for c, a in reverse_ite_cases(ast.args[1]):
+            yield And(c, ast.args[0]), a
+        for c, a in reverse_ite_cases(ast.args[2]):
+            yield And(c, Not(ast.args[0])), a
+    else:
+        yield true, ast
+
 def constraint_to_si(expr):
     """
     Convert a constraint to SI if possible.

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -361,6 +361,9 @@ def boolean_and_simplifier(*args):
         elif not a.is_true():
             new_args.append(a)
 
+    if not new_args:
+        return ast.bool.true
+
     if len(new_args) < len(args):
         return ast.all_operations.And(*new_args)
 
@@ -373,15 +376,22 @@ def boolean_and_simplifier(*args):
 
     if any(len(arg.args) != 2 for arg in fargs):
         return flattened
-    if   fargs[0].args[0] is fargs[0].args[0]:
-        target_var = fargs[0].args[0]
-    elif fargs[0].args[0] is fargs[1].args[0]:
-        target_var = fargs[0].args[0]
-    elif fargs[1].args[0] is fargs[0].args[0]:
-        target_var = fargs[0].args[1]
-    elif fargs[1].args[0] is fargs[1].args[0]:
-        target_var = fargs[0].args[1]
-    else:
+
+    target_var = None
+
+    # Determine the unknown variable
+    if fargs[0].args[0].symbolic:
+        if fargs[0].args[0] is fargs[1].args[0]:
+            target_var = fargs[0].args[0]
+        elif fargs[0].args[0] is fargs[1].args[1]:
+            target_var = fargs[0].args[0]
+    elif fargs[0].args[1].symbolic:
+        if fargs[0].args[1] is fargs[1].args[0]:
+            target_var = fargs[0].args[1]
+        elif fargs[0].args[1] is fargs[1].args[1]:
+            target_var = fargs[0].args[1]
+
+    if target_var is None:
         return flattened
 
     # we now know that the And is a series of binary conditions over a single variable.

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -368,7 +368,47 @@ def boolean_and_simplifier(*args):
         # a And a == a
         return tuple(OrderedSet(args))
 
-    return _flatten_simplifier('And', _flattening_filter, *args)
+    flattened = _flatten_simplifier('And', _flattening_filter, *args)
+    fargs = flattened.args if flattened is not None else args
+
+    if any(len(arg.args) != 2 for arg in fargs):
+        return flattened
+    if   fargs[0].args[0] is fargs[0].args[0]:
+        target_var = fargs[0].args[0]
+    elif fargs[0].args[0] is fargs[1].args[0]:
+        target_var = fargs[0].args[0]
+    elif fargs[1].args[0] is fargs[0].args[0]:
+        target_var = fargs[0].args[1]
+    elif fargs[1].args[0] is fargs[1].args[0]:
+        target_var = fargs[0].args[1]
+    else:
+        return flattened
+
+    # we now know that the And is a series of binary conditions over a single variable.
+    # we can optimize accordingly.
+    # right now it's just check for eq/ne
+
+    eq_list = []
+    ne_list = []
+    for arg in fargs:
+        other = arg.args[1] if arg.args[0] is target_var else arg.args[0]
+        if arg.op == '__eq__':
+            eq_list.append(other)
+        elif arg.op == '__ne__':
+            ne_list.append(other)
+        else:
+            return flattened
+
+    if not eq_list:
+        return flattened
+    if any(any(ne is eq for eq in eq_list) for ne in ne_list):
+        return ast.all_operations.false
+    if all(v.op == 'BVV' for v in eq_list) and all(v.op == 'BVV' for v in ne_list):
+        mustbe = eq_list[0]
+        if any(eq.args[0] != mustbe.args[0] for eq in eq_list):
+            return ast.all_operations.false
+        return target_var == eq_list[0]
+    return flattened
 
 def boolean_or_simplifier(*args):
     if len(args) == 1:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1,5 +1,6 @@
 import claripy
 import nose
+from functools import reduce
 
 def test_smudging():
     x = claripy.BVS('x', 32)
@@ -269,6 +270,19 @@ def raw_ite(solver_type):
     nose.tools.assert_equal(ss.eval(y/x, 100), ( 2, ))
     nose.tools.assert_equal(sorted(ss.eval(x, 100)), [ 1, 10, 100 ])
     nose.tools.assert_equal(sorted(ss.eval(y, 100)), [ 2, 20, 200 ])
+
+def test_ite_reverse():
+    a = claripy.BVS('a', 32)
+    cases = [(a == i, claripy.BVV(i, 32)) for i in range(30)]
+    ast = claripy.ite_cases(cases, -1)
+    ext_cases = list(claripy.reverse_ite_cases(ast))
+
+    assert sum(1 if case.op == 'And' else 0 for case, _ in ext_cases)
+    for case, val in ext_cases:
+        if case.op == 'And':
+            assert claripy.is_true(val == -1)
+        else:
+            assert any(case is orig_case and val is orig_val for orig_case, orig_val in cases)
 
 def test_bool():
     bc = claripy.backends.concrete

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1,6 +1,6 @@
 import claripy
 import nose
-from functools import reduce
+
 
 def test_smudging():
     x = claripy.BVS('x', 32)
@@ -314,9 +314,9 @@ def test_get_byte():
 def test_extract_concat_simplify():
     a = claripy.BVS("a", 32)
     assert a[31:0] is a
-    assert a[31:8].concat(a[7:0]) is a
-    assert a[31:16].concat(a[15:8], a[7:0]) is a
-    assert a[31:24].concat(a[23:16], a[15:8], a[7:0]) is a
+    assert a[31:8].concat(a[7:0]) is a  # pylint:disable=no-member
+    assert a[31:16].concat(a[15:8], a[7:0]) is a  # pylint:disable=no-member
+    assert a[31:24].concat(a[23:16], a[15:8], a[7:0]) is a  # pylint:disable=no-member
 
     a = claripy.BVS("a", 32)
     b = a + 100


### PR DESCRIPTION
Adds a reverse operation for for ite_cases and tweaks the And simplifier so it produces sane results. The one concern is, as always, whether the simplifier tweaks are too heavy. I don't think they should be, but I'd like another pair of eyes on it.