### PR TITLE
Spring cleaning july 2018

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -97,9 +97,6 @@ class Base(ana.Storable):
         :param variables:       The symbolic variables present in the AST (default: empty set)
         :param symbolic:        A flag saying whether or not the AST is symbolic (default: False)
         :param length:          An integer specifying the length of this AST (default: None)
-        :param collapsible:     A flag of whether or not Claripy can feel free to collapse this AST. This is mostly used
-                                to keep Claripy from collapsing Reverse operations, so that they can be undone with
-                                another Reverse.
         :param simplified:      A measure of how simplified this AST is. 0 means unsimplified, 1 means fast-simplified
                                 (basically, just undoing the Reverse op), and 2 means simplified through z3.
         :param errored:         A set of backends that are known to be unable to handle this AST.
@@ -194,7 +191,7 @@ class Base(ana.Storable):
         return self.op, tuple(str(a) if isinstance(a, numbers.Number) else hash(a) for a in self.args), self.symbolic, hash(self.variables), str(self.length)
 
     #pylint:disable=attribute-defined-outside-init
-    def __a_init__(self, op, args, variables=None, symbolic=None, length=None, collapsible=None, simplified=0, errored=None, eager_backends=None, add_variables=None, uninitialized=None, uc_alloc_depth=None, annotations=None): #pylint:disable=unused-argument
+    def __a_init__(self, op, args, variables=None, symbolic=None, length=None, simplified=0, errored=None, eager_backends=None, uninitialized=None, uc_alloc_depth=None, annotations=None): #pylint:disable=unused-argument
         """
         Initializes an AST. Takes the same arguments as ``Base.__new__()``
 

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -230,11 +230,6 @@ class Base(ana.Storable):
         if len(args) == 0:
             raise ClaripyOperationError("AST with no arguments!")
 
-        #if self.op != 'I':
-        #    for a in args:
-        #        if not isinstance(a, Base) and type(a) not in (int, long, bool, str, unicode):
-        #            import ipdb; ipdb.set_trace()
-        #            l.warning(ClaripyOperationError("Un-wrapped native object of type %s!" % type(a)))
     #pylint:enable=attribute-defined-outside-init
 
     def make_uuid(self, uuid=None):
@@ -713,8 +708,7 @@ class Base(ana.Storable):
                 else:
                     continue
 
-            if arg_a.op in ('I', 'BVS', 'FPS'):
-                # This is a leaf node in AST tree
+            if arg_a.op in operations.leaf_operations:
                 if arg_a is not arg_b:
                     return False
 
@@ -804,7 +798,7 @@ class Base(ana.Storable):
             # let's no go into this right now
             return self
 
-        if any(a.op in {'BVS', 'BVV', 'FPS', 'FPV', 'BoolS', 'BoolV'} for a in self.args):
+        if any(a.op in operations.leaf_operations for a in self.args):
             # burrowing through these is pretty funny
             return self
 
@@ -822,7 +816,7 @@ class Base(ana.Storable):
         return old_true.__class__(old_true.op, new_args, length=self.length)
 
     def _excavate_ite(self):
-        if self.op in { 'BVS', 'I', 'BVV' } or self.annotations:
+        if self.op in operations.leaf_operations or self.annotations:
             return self
 
         excavated_args = [ (a.ite_excavated if isinstance(a, Base) else a) for a in self.args ]
@@ -972,7 +966,7 @@ class Base(ana.Storable):
             return self
 
 def simplify(e):
-    if isinstance(e, Base) and e.op == 'I':
+    if type(e) is BV and e.op == 'BVV':
         return e
 
     s = e._first_backend('simplify')

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -85,7 +85,7 @@ class Base(ana.Storable):
     LITE_SIMPLIFY=2
     UNSIMPLIFIED=0
 
-    def __new__(cls, op, args, **kwargs):
+    def __new__(cls, op, args, add_variables=None, **kwargs):
         """
         This is called when you create a new Base object, whether directly or through an operation.
         It finalizes the arguments (see the _finalize function, above) and then computes
@@ -120,8 +120,8 @@ class Base(ana.Storable):
         if 'errored' not in kwargs:
             kwargs['errored'] = set.union(set(), *(a._errored for a in a_args if isinstance(a, Base)))
 
-        if 'add_variables' in kwargs:
-            kwargs['variables'] = kwargs['variables'] | kwargs['add_variables']
+        if add_variables:
+            kwargs['variables'] = kwargs['variables'] | add_variables
 
         eager_backends = list(backends._eager_backends) if 'eager_backends' not in kwargs else kwargs['eager_backends']
 

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -966,7 +966,7 @@ class Base(ana.Storable):
             return self
 
 def simplify(e):
-    if type(e) is BV and e.op == 'BVV':
+    if isinstance(e, Base) and e.op in operations.leaf_operations:
         return e
 
     s = e._first_backend('simplify')

--- a/claripy/backends/__init__.py
+++ b/claripy/backends/__init__.py
@@ -79,7 +79,6 @@ class Backend(object):
                     self._op_raw[o] = getattr(op_module, o)
                 else:
                     l.debug("Operation %s not in op_module %s.", o, op_module)
-        self._op_raw['I'] = lambda thing: thing
 
     def _make_expr_ops(self, op_list, op_dict=None, op_class=None):
         """

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -960,7 +960,7 @@ length_none_operations = backend_comparator_operations | expression_comparator_o
 length_change_operations = backend_bitmod_operations
 length_new_operations = backend_creation_operations
 
-leaf_operations = backend_symbol_creation_operations | backend_creation_operations
+leaf_operations = backend_symbol_creation_operations | backend_creation_operations | backend_vsa_creation_operations
 leaf_operations_concrete = backend_creation_operations
 leaf_operations_symbolic = backend_symbol_creation_operations
 


### PR DESCRIPTION
- Replace references to 'I' with either BVV or nothing, depending on context
- Replace references to the list of leaf operations with `operations.leaf_operations`
- Add VSA ops to list of leaf operations
- Remove some dead code from the base constructor

partner to angr/angr#1155