### PR TITLE
Add __bool__ to VSA bool results

### DIFF
--- a/claripy/vsa/bool_result.py
+++ b/claripy/vsa/bool_result.py
@@ -118,6 +118,9 @@ class TrueResult(BoolResult):
     def __repr__(self):
         return '<True>'
 
+    def __bool__(self):
+        return True
+
 class FalseResult(BoolResult):
     cardinality = 1
 
@@ -158,6 +161,9 @@ class FalseResult(BoolResult):
         else:
             return NotImplemented
 
+    def __bool__(self):
+        return False
+
 class MaybeResult(BoolResult):
     cardinality = 2
 
@@ -194,6 +200,9 @@ class MaybeResult(BoolResult):
             return '<Maybe>'
         else:
             return '<Maybe(%s, %s)>' % (self._op, self._args)
+
+    def __bool__(self):
+        return False
 
 
 


### PR DESCRIPTION
so, um, a horrifying amount of claripy seems to want to be able to put strided interval objects in sets. Sets require members to be hashable and comparable. Comparison between two strided intervals currently does not return a bool. How did this ever work???????????????????????????????

Closes #94 