### PR TITLE
ValueSet: implement __mod__ operation

### DIFF
--- a/claripy/backends/backend_vsa.py
+++ b/claripy/backends/backend_vsa.py
@@ -74,6 +74,7 @@ class BackendVSA(Backend):
         self._op_raw['__or__'] = self._op_or
         self._op_raw['__xor__'] = self._op_xor
         self._op_raw['__and__'] = self._op_and
+        self._op_raw['__mod__'] = self._op_mod
 
     @staticmethod
     def _op_add(*args):
@@ -93,6 +94,9 @@ class BackendVSA(Backend):
     @staticmethod
     def _op_and(*args):
         return reduce(operator.__and__, args)
+    @staticmethod
+    def _op_mod(*args):
+        return reduce(operator.__mod__, args)
 
     def convert(self, expr):
         return Backend.convert(self, expr.ite_excavated if isinstance(expr, Base) else expr)

--- a/claripy/frontend_mixins/model_cache_mixin.py
+++ b/claripy/frontend_mixins/model_cache_mixin.py
@@ -246,7 +246,7 @@ class ModelCacheMixin(object):
         if len(results) != 0:
             constraints = (all_operations.And(*[
                 all_operations.Or(*[a!=v for a,v in zip(asts, r)]) for r in results
-            ]),) + extra_constraints
+            ]),) + tuple(extra_constraints)
         else:
             constraints = extra_constraints
 

--- a/claripy/frontends/full_frontend.py
+++ b/claripy/frontends/full_frontend.py
@@ -129,7 +129,7 @@ class FullFrontend(ConstrainedFrontend):
         if len(two) == 0: raise UnsatError("unsat during max()")
         elif len(two) == 1: return two[0]
 
-        c = extra_constraints + (UGE(e, two[0]), UGE(e, two[1]))
+        c = tuple(extra_constraints) + (UGE(e, two[0]), UGE(e, two[1]))
         try:
             return self._solver_backend.max(
                 e, extra_constraints=c,
@@ -149,7 +149,7 @@ class FullFrontend(ConstrainedFrontend):
         if len(two) == 0: raise UnsatError("unsat during min()")
         elif len(two) == 1: return two[0]
 
-        c = extra_constraints + (ULE(e, two[0]), ULE(e, two[1]))
+        c = tuple(extra_constraints) + (ULE(e, two[0]), ULE(e, two[1]))
         try:
             return self._solver_backend.min(
                 e, extra_constraints=c,

--- a/claripy/vsa/valueset.py
+++ b/claripy/vsa/valueset.py
@@ -365,6 +365,29 @@ class ValueSet(BackendObject):
             return new_vs
 
     @normalize_types_one_arg
+    def __mod__(self, other):
+        """
+        Binary operation: modulo
+
+        :param other: The other operand
+        :return: A StridedInterval or a ValueSet.
+        """
+        if isinstance(other, ValueSet):
+            # TODO: Handle more cases
+            raise NotImplementedError()
+
+        else:
+            new_vs = self.copy()
+
+            # Call __mode__ on the base class
+            new_vs._si = self._si.__mod__(other)
+
+            for region, si in new_vs._regions.items():
+                new_vs._regions[region] = si % other
+
+            return new_vs
+
+    @normalize_types_one_arg
     def __and__(self, other):
         """
         Binary operation: and


### PR DESCRIPTION
Without the `__mod__` operation implemented for `ValueSet` it is impossible to make a `full_init_state` with mode set to 'static':

```python
In [11]: p = angr.Project('/bin/grep')                                                                                         
WARNING | 2018-10-25 12:56:18,144 | cle.loader | The main binary is a position-independent executable. It is being loaded with a base address of 0x400000.

In [12]: p.factory.full_init_state(addr=p.entry, mode='static')                                                            
---------------------------------------------------------------------------
BackendUnsupportedError                   Traceback (most recent call last)
~/embedi/angr-dev/claripy/claripy/backends/__init__.py in convert(self, expr)
    159                     try:
--> 160                         r = self.call(expr.op, expr.args)
    161                     except BackendUnsupportedError:

~/embedi/angr-dev/claripy/claripy/backends/__init__.py in call(self, op, args)
    212             l.debug("received NotImplemented in %s.call() for operation %s", self, op)
--> 213             raise BackendUnsupportedError
    214 

BackendUnsupportedError: 

During handling of the above exception, another exception occurred:

BackendError                              Traceback (most recent call last)
~/embedi/angr-dev/claripy/claripy/frontends/light_frontend.py in eval(self, e, n, extra_constraints, exact)
     39         try:
---> 40             return tuple(self._solver_backend.eval(e, n))
     41         except BackendError:

~/embedi/angr-dev/claripy/claripy/backends/__init__.py in eval(self, expr, n, extra_constraints, solver, model_callback)
    446         return self._eval(
--> 447             self.convert(expr), n, extra_constraints=self.convert_list(extra_constraints),
    448             solver=solver, model_callback=model_callback

~/embedi/angr-dev/claripy/claripy/backends/backend_vsa.py in convert(self, expr)
     97     def convert(self, expr):
---> 98         return Backend.convert(self, expr.ite_excavated if isinstance(expr, Base) else expr)
     99 

~/embedi/angr-dev/claripy/claripy/backends/__init__.py in convert(self, expr)
    161                     except BackendUnsupportedError:
--> 162                         r = self.default_op(expr)
    163             except (RuntimeError, ctypes.ArgumentError) as e:

~/embedi/angr-dev/claripy/claripy/backends/__init__.py in default_op(self, expr)
    704         # pylint: disable=unused-argument
--> 705         raise BackendError('Backend %s does not support operation %s' % (self, expr.op))
    706 

BackendError: Backend <claripy.backends.backend_vsa.BackendVSA object at 0x00007f3e7bef8bf0> does not support operation __mod__

During handling of the above exception, another exception occurred:

ClaripyFrontendError                      Traceback (most recent call last)
~/embedi/angr-dev/angr/angr/state_plugins/solver.py in wrapped_f(*args, **kwargs)
     84         try:
---> 85             return f(*args, **kwargs)
     86         except claripy.UnsatError as e:

~/embedi/angr-dev/angr/angr/state_plugins/solver.py in _eval(self, e, n, extra_constraints, exact)
    477         """
--> 478         return self._solver.eval(e, n, extra_constraints=self._adjust_constraint_list(extra_constraints), exact=exact)
    479 

~/embedi/angr-dev/claripy/claripy/frontend_mixins/concrete_handler_mixin.py in eval(self, e, n, **kwargs)
      6         else:
----> 7             return super(ConcreteHandlerMixin, self).eval(e, n, **kwargs)
      8 

~/embedi/angr-dev/claripy/claripy/frontend_mixins/constraint_filter_mixin.py in eval(self, e, n, extra_constraints, **kwargs)
     39         ec = self._constraint_filter(extra_constraints)
---> 40         return super(ConstraintFilterMixin, self).eval(e, n, extra_constraints=ec, **kwargs)
     41 

~/embedi/angr-dev/claripy/claripy/frontends/light_frontend.py in eval(self, e, n, extra_constraints, exact)
     41         except BackendError:
---> 42             raise ClaripyFrontendError("Light solver can't handle this eval().")
     43 

ClaripyFrontendError: Light solver can't handle this eval().

The above exception was the direct cause of the following exception:

SimSolverModeError                        Traceback (most recent call last)
<ipython-input-12-db65dc08f35b> in <module>
----> 1 s = p.factory.full_init_state(addr=p.entry, mode='static')

~/embedi/angr-dev/angr/angr/factory.py in full_init_state(self, **kwargs)
    109         :rtype:                 SimState
    110         """
--> 111         return self.project.simos.state_full_init(**kwargs)
    112 
    113     def call_state(self, addr, *args, **kwargs):

~/embedi/angr-dev/angr/angr/simos/linux.py in state_full_init(self, **kwargs)
    285     def state_full_init(self, **kwargs):
    286         kwargs['addr'] = self._loader_addr
--> 287         return super(SimLinux, self).state_full_init(**kwargs)
    288 
    289     def prepare_function_symbol(self, symbol_name, basic_addr=None):

~/embedi/angr-dev/angr/angr/simos/simos.py in state_full_init(self, **kwargs)
    186 
    187     def state_full_init(self, **kwargs):
--> 188         return self.state_entry(**kwargs)
    189 
    190     def state_call(self, addr, *args, **kwargs):

~/embedi/angr-dev/angr/angr/simos/linux.py in state_entry(self, args, env, argc, **kwargs)
    232         # Dump the table onto the stack, calculate pointers to args, env, and auxv
    233         state.memory.store(state.regs.sp - 16, claripy.BVV(0, 8 * 16))
--> 234         argv = table.dump(state, state.regs.sp - 16)
    235         envp = argv + ((len(args) + 1) * state.arch.bytes)
    236         auxv = argv + ((len(args) + len(env) + 2) * state.arch.bytes)

~/embedi/angr-dev/angr/angr/tablespecs.py in dump(self, state, end_addr, align)
     62         size = self._str_len + ptr_size
     63         start_addr = end_addr - size
---> 64         zero_fill = state.solver.eval(start_addr % align)
     65         start_addr -= zero_fill
     66         start_str = start_addr + ptr_size

~/embedi/angr-dev/angr/angr/state_plugins/solver.py in eval(self, e, **kwargs)
    701         """
    702         # eval_upto already throws the UnsatError, no reason for us to worry about it
--> 703         return self.eval_upto(e, 1, **kwargs)[0]
    704 
    705     def eval_one(self, e, **kwargs):

~/embedi/angr-dev/angr/angr/state_plugins/solver.py in eval_upto(self, e, n, cast_to, **kwargs)
    684             return [self._cast_to(e, concrete_val, cast_to)]
    685 
--> 686         cast_vals = [self._cast_to(e, v, cast_to) for v in self._eval(e, n, **kwargs)]
    687         if len(cast_vals) == 0:
    688             raise SimUnsatError('Not satisfiable: %s, expected up to %d solutions' % (e.shallow_repr(), n))

~/embedi/angr-dev/angr/angr/state_plugins/solver.py in concrete_shortcut_tuple(self, *args, **kwargs)
    150         v = _concrete_value(args[0])
    151         if v is None:
--> 152             return f(self, *args, **kwargs)
    153         else:
    154             return ( v, )

~/embedi/angr-dev/angr/angr/state_plugins/sim_action_object.py in ast_stripper(*args, **kwargs)
     53         new_args = _raw_ast(args)
     54         new_kwargs = _raw_ast(kwargs)
---> 55         return f(*new_args, **new_kwargs)
     56     return ast_stripper
     57 

~/embedi/angr-dev/angr/angr/state_plugins/solver.py in wrapped_f(*args, **kwargs)
     87             raise SimUnsatError("Got an unsat result") from e
     88         except claripy.ClaripyFrontendError as e:
---> 89             raise SimSolverModeError("Claripy threw an error") from e
     90     return wrapped_f
     91 

SimSolverModeError: Claripy threw an error
```

This commit fixes the issue:

```python
In [1]: p = angr.Project('/bin/grep')                                                                                          
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-1-1787392c0034> in <module>
----> 1 p = angr.Project('/bin/grep')

NameError: name 'angr' is not defined

In [2]: import angr                                                                                                            

In [3]: p = angr.Project('/bin/grep')                                                                                          
WARNING | 2018-10-25 13:01:23,603 | cle.loader | The main binary is a position-independent executable. It is being loaded with a base address of 0x400000.

In [4]: p.factory.full_init_state(addr=p.entry, mode='static')
Out[4]: <SimState @ 0x7000000>
```