### PR TITLE
fix assertion on bool conversion on ASTs

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -624,7 +624,7 @@ class Base(ana.Storable):
         """
         raise ClaripyOperationError("Please don't iterate over, or split, AST nodes!")
 
-    def __nonzero__(self):
+    def __bool__(self):
         """
         This prevents people from accidentally using an AST as a condition. For
         example, the following was previously common::

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -493,6 +493,27 @@ def test_arith_shift():
     solver.add(a == -4)
     assert list(solver.eval(a >> 1, 2)) == [2**32-2]
 
+def test_bool_conversion():
+    a = claripy.BVV(42, 32)
+    try:
+        assert a == 42
+        assert False, "`assert ast` should raise an exception"
+    except claripy.ClaripyOperationError:
+        pass
+
+    try:
+        bool(a == 42)
+        assert False, "bool(ast) should raise an exception"
+    except claripy.ClaripyOperationError:
+        pass
+
+    try:
+        if a == 42:
+            pass
+        assert False, "`if ast` should raise an exception"
+    except claripy.ClaripyOperationError:
+        pass
+
 if __name__ == '__main__':
     test_multiarg()
     test_depth()
@@ -512,3 +533,4 @@ if __name__ == '__main__':
     test_signed_concrete()
     test_signed_symbolic()
     test_arith_shift()
+    test_bool_conversion()


### PR DESCRIPTION
`__nonzero__` is no longer used for `assert, if, and bool()`. `__bool__` is the new king.

This should not be merged until we merge https://github.com/angr/claripy/pull/106, to avoid conflict risk.