### PR TITLE
BackendZ3: Resolve Z3 AST hash collisions.

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -353,14 +353,16 @@ class BackendZ3(Backend):
         """
 
         z3_hash = z3.Z3_get_ast_hash(ctx, ast)
-        z3_ast_ref = ast.value # this seems to be the memory address
         z3_sort = z3.Z3_get_sort(ctx, ast).value
-        return "%d_%d_%d" % (z3_hash, z3_sort, z3_ast_ref)
+        return "%d_%d" % (z3_hash, z3_sort)
 
     def _abstract_internal(self, ctx, ast, split_on=None):
         h = self._z3_ast_hash(ctx, ast)
         try:
-            return self._ast_cache[h]
+            cached_ast = self._ast_cache[h]
+            # are two ASTs equal?
+            if z3.Z3_is_eq_ast(ctx, ast, cached_ast._model_z3.ast):
+                return cached_ast
         except KeyError:
             pass
 

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1,4 +1,4 @@
-import sys
+
 import os
 import z3
 import ctypes
@@ -251,13 +251,13 @@ class BackendZ3(Backend):
         self._simplification_cache_val.clear()
 
     @condom
-    def _size(self, e):
-        if not isinstance(e, z3.BitVecRef) and not isinstance(e, z3.BitVecNumRef):
-            l.debug("Unable to determine length of value of type %s", e.__class__)
-            raise BackendError("Unable to determine length of value of type %s" % e.__class__)
-        return e.size()
+    def _size(self, a):
+        if not isinstance(a, z3.BitVecRef) and not isinstance(a, z3.BitVecNumRef):
+            l.debug("Unable to determine length of value of type %s", a.__class__)
+            raise BackendError("Unable to determine length of value of type %s" % a.__class__)
+        return a.size()
 
-    def _name(self, e): #pylint:disable=unused-argument
+    def _name(self, o): #pylint:disable=unused-argument
         l.warning("BackendZ3.name() called. This is weird.")
         raise BackendError("name is not implemented yet")
 
@@ -327,7 +327,7 @@ class BackendZ3(Backend):
     #
 
     @condom
-    def _convert(self, obj):
+    def _convert(self, obj):  # pylint:disable=arguments-differ
         if isinstance(obj, FSort):
             return z3.FPSort(obj.exp, obj.mantissa, ctx=self._context)
         elif isinstance(obj, RM):
@@ -355,20 +355,19 @@ class BackendZ3(Backend):
             l.debug("BackendZ3 encountered unexpected type %s", type(obj))
             raise BackendError("unexpected type %s encountered in BackendZ3" % type(obj))
 
-    def call(self, *args, **kwargs):
+    def call(self, *args, **kwargs):  # pylint;disable=arguments-differ
         return Backend.call(self, *args, **kwargs)
 
     @condom
-    def _abstract(self, z):
+    def _abstract(self, e):
         #return self._abstract(z, split_on=split_on)[0]
-        return self._abstract_internal(z.ctx.ctx, z.ast)
+        return self._abstract_internal(e.ctx.ctx, e.ast)
 
     @staticmethod
-    def _z3_ast_hash(ctx, ast):
+    def _z3_ast_hash(ast):
         """
         This is a better hashing function for z3 Ast objects. Z3_get_ast_hash() creates too many hash collisions.
 
-        :param ctx: A z3 Context.
         :param ast: A z3 Ast object.
         :return:    An integer - the hash.
         """
@@ -376,7 +375,7 @@ class BackendZ3(Backend):
         return ast.value
 
     def _abstract_internal(self, ctx, ast, split_on=None):
-        h = self._z3_ast_hash(ctx, ast)
+        h = self._z3_ast_hash(ast)
         try:
             cached_ast, _ = self._ast_cache[h]
             return cached_ast
@@ -831,11 +830,11 @@ class BackendZ3(Backend):
 
         return max(vals)
 
-    def _simplify(self, expr): #pylint:disable=W0613,R0201
+    def _simplify(self, e): #pylint:disable=W0613,R0201
         raise Exception("This shouldn't be called. Bug Yan.")
 
     @condom
-    def simplify(self, expr):
+    def simplify(self, expr):  #pylint:disable=arguments-differ
         if expr._simplified:
             return expr
 


### PR DESCRIPTION
Thanks to the recent patch that makes claripy less recursive, we are
probably releasing Z3 objects more often than before. A negative
consequence is that our Z3 AST hash, which uses to heavily rely on memory
addresses of Z3 ASTs, now have a much higher chance to collide. This patch
solves this problem in a painful way: Always check if the cached Z3 object
is the same as the one being abstracted, and do not return the cached one
if they are not equal to avoid AST collisions. It will surely impact the
speed, but it is still better than returning incorrect results.

Thanks @basher for reporting another issue that led us to find this bug.

Update: The old fix introduces way too many equality checks, which greatly slows down simplifications when ASTs are big and deep. Here is a better solution: We convert `_ast_cache` into an LRUCache and store both high-level claripy ASTs and the low-level `z3types.Ast` objects. Most importantly, we increment the Z3 reference counter of the `z3types.Ast` object so it will not be immediately released. This allows us to leverage the internal de-duplication mechanism of Z3 (if there is any), which hopefully will use the same pointer for AST sub-trees if they are the same. Hence we can use pointer values of low-level Z3 ASTs to key our `_ast_cache` dict. When a low-level AST is popped out of the `_ast_cache` dict, we decrement its reference counter inside Z3.