### PR TITLE
Fix to account for cases where the first argument of a multi-argument expression is a constant

### DIFF
--- a/claripy/balancer.py
+++ b/claripy/balancer.py
@@ -238,7 +238,7 @@ class Balancer(object):
         """
         if len(t.args) < 2:
             l.debug("can't do anything with an unop bool")
-            multivalued_guys_count = 0
+        multivalued_guys_count = 0
         for a in t.args:
             if hasattr(a, 'cardinality') and a.cardinality > 1:
                 multivalued_guys_count += 1

--- a/claripy/balancer.py
+++ b/claripy/balancer.py
@@ -238,12 +238,15 @@ class Balancer(object):
         """
         if len(t.args) < 2:
             l.debug("can't do anything with an unop bool")
-        elif t.args[1].cardinality > 1:
+            multivalued_guys_count = 0
+        for a in t.args:
+            if hasattr(a, 'cardinality') and a.cardinality > 1:
+                multivalued_guys_count += 1
+        if multivalued_guys_count > 1:
             l.debug("can't do anything because we have multiple multivalued guys")
             return False
         else:
             return True
-
 
     #
     # Assumptions management


### PR DESCRIPTION
Balancer was improperly giving up handling an expression, as it checked the second argument only for multivalued-ness and assumed the first argument was as well.

Fixes crazy jumptable bugs, among probably many other things.