### PR TITLE
This PR removes ANA from claripy

### DIFF
--- a/claripy/__init__.py
+++ b/claripy/__init__.py
@@ -20,14 +20,6 @@ from . import backends as _backends_module
 from .backends import Backend
 from .backend_object import BackendObject
 
-#
-# connect to ANA
-#
-
-import ana
-if os.environ.get('REMOTE', False):
-    ana.set_dl(ana.MongoDataLayer(()))
-
 
 #
 # backend objects

--- a/claripy/annotation.py
+++ b/claripy/annotation.py
@@ -1,4 +1,4 @@
-class Annotation(object):
+class Annotation:
     """
     Annotations are used to achieve claripy's goal of being an arithmetic instrumentation engine.
     They provide a means to pass extra information to the claripy backends.

--- a/claripy/backend_manager.py
+++ b/claripy/backend_manager.py
@@ -1,4 +1,4 @@
-class BackendManager(object):
+class BackendManager:
     def __init__(self):
         self._eager_backends = [ ]
         self._quick_backends = [ ]

--- a/claripy/backend_object.py
+++ b/claripy/backend_object.py
@@ -1,4 +1,4 @@
-class BackendObject(object):
+class BackendObject:
     """
     This is a base class for custom backend objects to implement.
 

--- a/claripy/backends/__init__.py
+++ b/claripy/backends/__init__.py
@@ -6,7 +6,7 @@ import threading
 import logging
 l = logging.getLogger('claripy.backend')
 
-class Backend(object):
+class Backend:
     """
     Backends are Claripy's workhorses. Claripy exposes ASTs (claripy.ast.Base objects)
     to the world, but when actual computation has to be done, it pushes those

--- a/claripy/backends/backendremote.py
+++ b/claripy/backends/backendremote.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     remotetasks = None
 
-class TrackingSolver(object):
+class TrackingSolver:
     def __init__(self, sz3):
         self.sz3 = sz3
         self.constraints = []

--- a/claripy/balancer.py
+++ b/claripy/balancer.py
@@ -3,7 +3,7 @@ import operator
 
 l = logging.getLogger('claripy.balancer')
 
-class Balancer(object):
+class Balancer:
     """
     The Balancer is an equation redistributor. The idea is to take an AST and rebalance it to, for example, isolate
     unknown terms on one side of an inequality.

--- a/claripy/fp.py
+++ b/claripy/fp.py
@@ -47,7 +47,7 @@ RM_RTP = RM('RTP')
 RM_RTN = RM('RTN')
 RM_RTZ = RM('RTZ')
 
-class FSort(object):
+class FSort:
     def __init__(self, name, exp, mantissa):
         self.name = name
         self.exp = exp

--- a/claripy/frontend.py
+++ b/claripy/frontend.py
@@ -3,14 +3,17 @@
 import logging
 import numbers
 
-import ana
-
 l = logging.getLogger("claripy.frontends.frontend")
 
 
-class Frontend(ana.Storable):
+class Frontend:
     def __init__(self):
         pass
+
+    def __getstate__(self):
+        return (True) # need to return something so that pickle calls setstate
+    def __setstate__(self, s): #pylint:disable=unused-argument
+        return
 
     def branch(self):
         c = self.blank_copy()
@@ -27,20 +30,6 @@ class Frontend(ana.Storable):
 
     def _copy(self, c): #pylint:disable=no-self-use,unused-argument
         return
-
-    #
-    # Storable support
-    #
-
-    @property
-    def uuid(self):
-        return self.ana_uuid
-
-    def _ana_getstate(self):
-        return None
-
-    def _ana_setstate(self, s):
-        pass
 
     #
     # Stuff that should be implemented by subclasses

--- a/claripy/frontend_mixins/composited_cache_mixin.py
+++ b/claripy/frontend_mixins/composited_cache_mixin.py
@@ -2,7 +2,7 @@
 #misses = 0
 #ejects = 0
 
-class CompositedCacheMixin(object):
+class CompositedCacheMixin:
     def __init__(self, *args, **kwargs):
         super(CompositedCacheMixin, self).__init__(*args, **kwargs)
         self._merged_solvers = { }

--- a/claripy/frontend_mixins/composited_cache_mixin.py
+++ b/claripy/frontend_mixins/composited_cache_mixin.py
@@ -15,8 +15,8 @@ class CompositedCacheMixin(object):
         super(CompositedCacheMixin, self)._copy(c)
         c._merged_solvers = dict(self._merged_solvers)
 
-    def _ana_setstate(self, s):
-        super(CompositedCacheMixin, self)._ana_setstate(s)
+    def __setstate__(self, base_state):
+        super().__setstate__(base_state)
         self._merged_solvers = { }
 
     #

--- a/claripy/frontend_mixins/concrete_handler_mixin.py
+++ b/claripy/frontend_mixins/concrete_handler_mixin.py
@@ -1,4 +1,4 @@
-class ConcreteHandlerMixin(object):
+class ConcreteHandlerMixin:
     def eval(self, e, n, **kwargs): #pylint:disable=unused-argument
         c = self._concrete_value(e)
         if c is not None:

--- a/claripy/frontend_mixins/constraint_deduplicator_mixin.py
+++ b/claripy/frontend_mixins/constraint_deduplicator_mixin.py
@@ -1,4 +1,4 @@
-class ConstraintDeduplicatorMixin(object):
+class ConstraintDeduplicatorMixin:
     def __init__(self, *args, **kwargs):
         super(ConstraintDeduplicatorMixin, self).__init__(*args, **kwargs)
         self._constraint_hashes = set()

--- a/claripy/frontend_mixins/constraint_deduplicator_mixin.py
+++ b/claripy/frontend_mixins/constraint_deduplicator_mixin.py
@@ -11,16 +11,12 @@ class ConstraintDeduplicatorMixin(object):
         super(ConstraintDeduplicatorMixin, self)._copy(c)
         c._constraint_hashes = set(self._constraint_hashes)
 
-    #
-    # Serialization
-    #
+    def __getstate__(self):
+        return self._constraint_hashes, super().__getstate__()
 
-    def _ana_getstate(self):
-        return self._constraint_hashes, super(ConstraintDeduplicatorMixin, self)._ana_getstate()
-
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         self._constraint_hashes, base_state = s
-        super(ConstraintDeduplicatorMixin, self)._ana_setstate(base_state)
+        super().__setstate__(base_state)
 
     def simplify(self, **kwargs):
         added = super(ConstraintDeduplicatorMixin, self).simplify(**kwargs)

--- a/claripy/frontend_mixins/constraint_expansion_mixin.py
+++ b/claripy/frontend_mixins/constraint_expansion_mixin.py
@@ -3,7 +3,7 @@
 import logging
 l = logging.getLogger("claripy.frontends.cache_mixin")
 
-class ConstraintExpansionMixin(object):
+class ConstraintExpansionMixin:
     def eval(self, e, n, extra_constraints=(), exact=None, **kwargs):
         results = super(ConstraintExpansionMixin, self).eval(
             e, n,

--- a/claripy/frontend_mixins/constraint_filter_mixin.py
+++ b/claripy/frontend_mixins/constraint_filter_mixin.py
@@ -1,4 +1,4 @@
-class ConstraintFilterMixin(object):
+class ConstraintFilterMixin:
     def _constraint_filter(self, constraints, **kwargs):
         if type(constraints) not in (tuple, list):
             raise ClaripyValueError("The extra_constraints argument should be a list of constraints.")

--- a/claripy/frontend_mixins/constraint_fixer_mixin.py
+++ b/claripy/frontend_mixins/constraint_fixer_mixin.py
@@ -1,4 +1,4 @@
-class ConstraintFixerMixin(object):
+class ConstraintFixerMixin:
     def add(self, constraints, **kwargs):
         constraints = [ constraints ] if not isinstance(constraints, (list, tuple, set)) else constraints
 

--- a/claripy/frontend_mixins/debug_mixin.py
+++ b/claripy/frontend_mixins/debug_mixin.py
@@ -31,7 +31,7 @@ def _debug_iterator(i):
         yield v
     _log("FINISHED: " + str(i))
 
-class DebugMixin(object):
+class DebugMixin:
     def __init__(self, *args, **kwargs):
         super(DebugMixin, self).__init__(*args, **kwargs)
 

--- a/claripy/frontend_mixins/eager_resolution_mixin.py
+++ b/claripy/frontend_mixins/eager_resolution_mixin.py
@@ -1,4 +1,4 @@
-class EagerResolutionMixin(object):
+class EagerResolutionMixin:
     def _concrete_value(self, e):
         r = super(EagerResolutionMixin, self)._concrete_value(e)
         if r is not None:

--- a/claripy/frontend_mixins/model_cache_mixin.py
+++ b/claripy/frontend_mixins/model_cache_mixin.py
@@ -4,7 +4,7 @@ import itertools
 from claripy import errors
 
 
-class ModelCache(object):
+class ModelCache:
     _defaults = { 0, 0.0, True }
 
     def __init__(self, model):
@@ -70,7 +70,7 @@ class ModelCache(object):
     def eval_list(self, asts):
         return tuple(self.eval_ast(c) for c in asts)
 
-class ModelCacheMixin(object):
+class ModelCacheMixin:
     def __init__(self, *args, **kwargs):
         super(ModelCacheMixin, self).__init__(*args, **kwargs)
         self._models = set()

--- a/claripy/frontend_mixins/model_cache_mixin.py
+++ b/claripy/frontend_mixins/model_cache_mixin.py
@@ -95,29 +95,13 @@ class ModelCacheMixin(object):
         c._max_exhausted = weakref.WeakSet(self._max_exhausted)
         c._min_exhausted = weakref.WeakSet(self._min_exhausted)
 
-    def _ana_getstate(self):
-        return (
-            self._models,
-            self._exhausted,
-            tuple(self._eval_exhausted),
-            tuple(self._max_exhausted),
-            tuple(self._min_exhausted),
-            super(ModelCacheMixin, self)._ana_getstate()
-        )
-
-    def _ana_setstate(self, s):
-        (
-            self._models,
-            self._exhausted,
-            _eval_exhausted,
-            _max_exhausted,
-            _min_exhausted,
-            base_state
-        ) = s
-        super(ModelCacheMixin, self)._ana_setstate(base_state)
-        self._eval_exhausted = weakref.WeakSet(_eval_exhausted)
-        self._max_exhausted = weakref.WeakSet(_max_exhausted)
-        self._min_exhausted = weakref.WeakSet(_min_exhausted)
+    def __setstate__(self, base_state):
+        super().__setstate__(base_state)
+        self._models = set()
+        self._exhausted = False
+        self._eval_exhausted = weakref.WeakSet()
+        self._max_exhausted = weakref.WeakSet()
+        self._min_exhausted = weakref.WeakSet()
 
     #
     # Model cleaning

--- a/claripy/frontend_mixins/sat_cache_mixin.py
+++ b/claripy/frontend_mixins/sat_cache_mixin.py
@@ -11,12 +11,12 @@ class SatCacheMixin(object):
         super(SatCacheMixin, self)._copy(c)
         c._cached_satness = self._cached_satness
 
-    def _ana_getstate(self):
-        return self._cached_satness, super(SatCacheMixin, self)._ana_getstate()
+    def __getstate__(self):
+        return self._cached_satness, super().__getstate__()
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         self._cached_satness, base_state = s
-        super(SatCacheMixin, self)._ana_setstate(base_state)
+        super().__setstate__(base_state)
 
     #
     # SAT caching

--- a/claripy/frontend_mixins/sat_cache_mixin.py
+++ b/claripy/frontend_mixins/sat_cache_mixin.py
@@ -1,4 +1,4 @@
-class SatCacheMixin(object):
+class SatCacheMixin:
     def __init__(self, *args, **kwargs):
         super(SatCacheMixin, self).__init__(*args, **kwargs)
         self._cached_satness = None

--- a/claripy/frontend_mixins/simplify_helper_mixin.py
+++ b/claripy/frontend_mixins/simplify_helper_mixin.py
@@ -1,4 +1,4 @@
-class SimplifyHelperMixin(object):
+class SimplifyHelperMixin:
     def max(self, *args, **kwargs):
         self.simplify()
         return super(SimplifyHelperMixin, self).max(*args, **kwargs)

--- a/claripy/frontend_mixins/simplify_skipper_mixin.py
+++ b/claripy/frontend_mixins/simplify_skipper_mixin.py
@@ -1,4 +1,4 @@
-class SimplifySkipperMixin(object):
+class SimplifySkipperMixin:
     def __init__(self, *args, **kwargs):
         super(SimplifySkipperMixin, self).__init__(*args, **kwargs)
         self._simplified = True

--- a/claripy/frontend_mixins/simplify_skipper_mixin.py
+++ b/claripy/frontend_mixins/simplify_skipper_mixin.py
@@ -11,12 +11,12 @@ class SimplifySkipperMixin(object):
         super(SimplifySkipperMixin, self)._copy(c)
         c._simplified = self._simplified
 
-    def _ana_getstate(self):
-        return self._simplified, super(SimplifySkipperMixin, self)._ana_getstate()
+    def __getstate__(self):
+        return self._simplified, super().__getstate__()
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         self._simplified, base_state = s
-        super(SimplifySkipperMixin, self)._ana_setstate(base_state)
+        super().__setstate__(base_state)
 
     #
     # Simplification skipping

--- a/claripy/frontend_mixins/solve_block_mixin.py
+++ b/claripy/frontend_mixins/solve_block_mixin.py
@@ -1,4 +1,4 @@
-class SolveBlockMixin(object):
+class SolveBlockMixin:
     def __init__(self, *args, **kwargs):
         super(SolveBlockMixin, self).__init__(*args, **kwargs)
         self.can_solve = True

--- a/claripy/frontend_mixins/solve_block_mixin.py
+++ b/claripy/frontend_mixins/solve_block_mixin.py
@@ -11,6 +11,12 @@ class SolveBlockMixin(object):
         super(SolveBlockMixin, self)._copy(c)
         c.can_solve = self.can_solve
 
+    def __getstate__(self):
+        return self.can_solve, super().__getstate__()
+    def __setstate__(self, s):
+        self.can_solve, base_state = s
+        super().__setstate__(base_state)
+
     def eval(self, *args, **kwargs):
         assert self.can_solve
         return super(SolveBlockMixin, self).eval(*args, **kwargs)

--- a/claripy/frontends/composite_frontend.py
+++ b/claripy/frontends/composite_frontend.py
@@ -38,13 +38,13 @@ class CompositeFrontend(ConstrainedFrontend):
     # Serialization stuff
     #
 
-    def _ana_getstate(self):
-        return self._solvers, self._template_frontend, self._unsat, self._track, super(CompositeFrontend, self)._ana_getstate()
+    def __getstate__(self):
+        return self._solvers, self._template_frontend, self._unsat, self._track, super().__getstate__()
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         self._solvers, self._template_frontend, self._unsat, self._track, base_state = s
         self._owned_solvers = weakref.WeakKeyDictionary({s:True for s in self._solver_list})
-        super(CompositeFrontend, self)._ana_setstate(base_state)
+        super().__setstate__(base_state)
 
     def downsize(self):
         for e in self._solver_list:
@@ -131,9 +131,9 @@ class CompositeFrontend(ConstrainedFrontend):
         Returns a sequence of the solvers that self and others share.
         """
 
-        solvers_by_id = { s.uuid: s for s in self._solver_list }
+        solvers_by_id = { id(s): s for s in self._solver_list }
         common_solvers = set(solvers_by_id.keys())
-        other_sets = [ { s.uuid for s in cs._solver_list } for cs in others ]
+        other_sets = [ { id(s) for s in cs._solver_list } for cs in others ]
         for o in other_sets: common_solvers &= o
 
         return [ solvers_by_id[s] for s in common_solvers ]
@@ -401,7 +401,7 @@ class CompositeFrontend(ConstrainedFrontend):
         l.debug("Merging %s with %d other solvers.", self, len(others))
         merged = self.blank_copy()
         common_solvers = self._shared_solvers(others)
-        common_ids = { s.uuid for s in common_solvers }
+        common_ids = { id(s) for s in common_solvers }
         l.debug("... %s common solvers", len(common_solvers))
 
         for s in common_solvers:
@@ -412,7 +412,7 @@ class CompositeFrontend(ConstrainedFrontend):
             for v in s.variables:
                 merged._solvers[v] = s
 
-        noncommon_solvers = [ [ s for s in cs._solver_list if s.uuid not in common_ids ] for cs in [self]+others ]
+        noncommon_solvers = [ [ s for s in cs._solver_list if id(s) not in common_ids ] for cs in [self]+others ]
 
         l.debug("... merging noncommon solvers")
         combined_noncommons = [ ]

--- a/claripy/frontends/composite_frontend.py
+++ b/claripy/frontends/composite_frontend.py
@@ -101,13 +101,13 @@ class CompositeFrontend(ConstrainedFrontend):
         if v is not None and isinstance(v, Base):
             names.update(v.variables)
         if lst is not None:
-            for e in lst:
-                if isinstance(e, Base):
-                    names.update(e.variables)
+            for ee in lst:
+                if isinstance(ee, Base):
+                    names.update(ee.variables)
         if lst2 is not None:
-            for e in lst2:
-                if isinstance(e, Base):
-                    names.update(e.variables)
+            for ee in lst2:
+                if isinstance(ee, Base):
+                    names.update(ee.variables)
         return names
 
     def _merged_solver_for(self, *args, **kwargs):
@@ -173,12 +173,12 @@ class CompositeFrontend(ConstrainedFrontend):
             old_solvers = self._solvers_for_variables(s.variables)
             if len(new_solvers) == len(old_solvers):
                 done = set()
-                for s in s.split():
-                    if s in done:
+                for ss in s.split():
+                    if ss in done:
                         continue
-                    done.add(s)
-                    v = min(iter(s.variables))
-                    self._solvers[v].update(s)
+                    done.add(ss)
+                    v = min(iter(ss.variables))
+                    self._solvers[v].update(ss)
             else:
                 for ns in new_solvers:
                     self._owned_solvers[ns] = True

--- a/claripy/frontends/constrained_frontend.py
+++ b/claripy/frontends/constrained_frontend.py
@@ -125,7 +125,7 @@ class ConstrainedFrontend(Frontend):  # pylint:disable=abstract-method
     def satisfiable(self, extra_constraints=(), exact=None):
         raise NotImplementedError("satisfiable() is not implemented")
 
-    def batch_eval(self, e, n, extra_constraints=(), exact=None):
+    def batch_eval(self, exprs, n, extra_constraints=(), exact=None):
         raise NotImplementedError("batch_eval() is not implemented")
 
     def eval(self, e, n, extra_constraints=(), exact=None):

--- a/claripy/frontends/constrained_frontend.py
+++ b/claripy/frontends/constrained_frontend.py
@@ -30,17 +30,15 @@ class ConstrainedFrontend(Frontend):  # pylint:disable=abstract-method
         c.finalize()
 
     #
-    # Storable support
+    # Serialization support
     #
 
-    def _ana_getstate(self):
-        self.finalize()
-        return self.constraints, self.variables, Frontend._ana_getstate(self)
+    def __getstate__(self):
+        return self.constraints, self.variables, super().__getstate__()
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         self.constraints, self.variables, base_state = s
-        Frontend._ana_setstate(self, base_state)
-        self._finalized = True
+        super().__setstate__(base_state)
 
     #
     # Constraint management

--- a/claripy/frontends/full_frontend.py
+++ b/claripy/frontends/full_frontend.py
@@ -31,19 +31,19 @@ class FullFrontend(ConstrainedFrontend):
         c._to_add = list(self._to_add)
 
     #
-    # Storable support
+    # Serialization support
     #
 
-    def _ana_getstate(self):
-        return self._solver_backend.__class__.__name__, self.timeout, self._track, ConstrainedFrontend._ana_getstate(self)
+    def __getstate__(self):
+        return self._solver_backend.__class__.__name__, self.timeout, self._track, super().__getstate__()
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         backend_name, self.timeout, self._track, base_state = s
         self._solver_backend = backends._backends_by_type[backend_name]
         #self._tls = None
         self._tls = threading.local()
         self._to_add = [ ]
-        ConstrainedFrontend._ana_setstate(self, base_state)
+        super().__setstate__(base_state)
 
     #
     # Frontend Creation

--- a/claripy/frontends/hybrid_frontend.py
+++ b/claripy/frontends/hybrid_frontend.py
@@ -48,15 +48,15 @@ class HybridFrontend(Frontend):
         return self._exact_frontend.variables
 
     #
-    # Storable support
+    # Serialization support
     #
 
-    def _ana_getstate(self):
-        return (self._exact_frontend, self._approximate_frontend, Frontend._ana_getstate(self))
+    def __getstate__(self):
+        return (self._exact_frontend, self._approximate_frontend, super().__getstate__())
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         self._exact_frontend, self._approximate_frontend, base_state = s
-        Frontend._ana_setstate(self, base_state)
+        super().__setstate__(base_state)
 
     #
     # Hybrid solving

--- a/claripy/frontends/light_frontend.py
+++ b/claripy/frontends/light_frontend.py
@@ -20,15 +20,15 @@ class LightFrontend(ConstrainedFrontend):
         super(LightFrontend, self)._copy(c)
 
     #
-    # Storable support
+    # Serialization support
     #
 
-    def _ana_getstate(self):
-        return self._solver_backend.__class__.__name__, ConstrainedFrontend._ana_getstate(self)
+    def __getstate__(self):
+        return self._solver_backend.__class__.__name__, super().__getstate__()
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         solver_backend_name, base_state = s
-        ConstrainedFrontend._ana_setstate(self, base_state)
+        super().__setstate__(base_state)
         self._solver_backend = backends._backends_by_type[solver_backend_name]
 
     #

--- a/claripy/frontends/replacement_frontend.py
+++ b/claripy/frontends/replacement_frontend.py
@@ -125,7 +125,7 @@ class ReplacementFrontend(ConstrainedFrontend):
         self._actual_frontend.downsize()
         self._replacement_cache.clear()
 
-    def _ana_getstate(self):
+    def __getstate__(self):
         return (
             self._allow_symbolic,
             self._unsafe_replacement,
@@ -135,10 +135,10 @@ class ReplacementFrontend(ConstrainedFrontend):
             self._replacements,
             self._actual_frontend,
             self._validation_frontend,
-            super(ReplacementFrontend, self)._ana_getstate()
+            super().__getstate__()
         )
 
-    def _ana_setstate(self, s):
+    def __setstate__(self, s):
         (
             self._allow_symbolic,
             self._unsafe_replacement,
@@ -151,7 +151,7 @@ class ReplacementFrontend(ConstrainedFrontend):
             base_state
         ) = s
 
-        super(ReplacementFrontend, self)._ana_setstate(base_state)
+        super().__setstate__(base_state)
         self._replacement_cache = weakref.WeakKeyDictionary(self._replacements)
 
     #

--- a/claripy/vsa/abstract_location.py
+++ b/claripy/vsa/abstract_location.py
@@ -1,6 +1,6 @@
 from ..backend_object import BackendObject
 
-class Segment(object):
+class Segment:
     def __init__(self, offset, size=0):
         self.offset = offset
         self.size = size

--- a/claripy/vsa/strided_interval.py
+++ b/claripy/vsa/strided_interval.py
@@ -150,7 +150,7 @@ si_id_ctr = itertools.count()
 allow_dsis = False
 
 
-class WarrenMethods(object):
+class WarrenMethods:
     """
         Methods as suggested in book.
         Hackers Delight.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     python_requires='>=3.5',
     packages=packages,
     install_requires=[
-        'ana',
         'z3-solver==4.5.1.0.post2',
         'future',
         'cachetools'

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,8 +1,5 @@
 import claripy
-import ana
-import nose
 import pickle
-import tempfile
 
 import logging
 l = logging.getLogger('claripy.test.serial')
@@ -14,12 +11,13 @@ def test_pickle_ast():
     b = claripy.BVS('x', 32, explicit_name=True)
 
     c = a+b
-    nose.tools.assert_equal(bz.convert(c).__module__, 'z3.z3')
-    nose.tools.assert_equal(str(bz.convert(c)), '1 + x')
+    assert bz.convert(c).__module__ == 'z3.z3'
+    assert str(bz.convert(c)), '1 + x'
 
     c_copy = pickle.loads(pickle.dumps(c, -1))
-    nose.tools.assert_equal(bz.convert(c_copy).__module__, 'z3.z3')
-    nose.tools.assert_equal(str(bz.convert(c_copy)), '1 + x')
+    assert c_copy is c
+    assert bz.convert(c_copy).__module__ == 'z3.z3'
+    assert str(bz.convert(c_copy)) == '1 + x'
 
 def test_pickle_frontend():
     s = claripy.Solver()
@@ -36,12 +34,8 @@ def test_pickle_frontend():
     s = pickle.loads(ss)
     assert s.eval(x, 10), (1,)
 
-def test_datalayer():
-    l.info("Running test_datalayer")
-
-    pickle_dir = tempfile.mkdtemp()
-    ana.set_dl(ana.DirDataLayer(pickle_dir))
-    l.debug("Pickling to %s",pickle_dir)
+def test_identity():
+    l.info("Running test_identity")
 
     a = claripy.BVV(1, 32)
     b = claripy.BVS("x", 32)
@@ -49,39 +43,35 @@ def test_datalayer():
     d = a+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b+b
 
     l.debug("Storing!")
-    a.ana_store()
-    c_info = c.ana_store()
-    d_info = d.ana_store()
+    c_info = pickle.dumps(c)
+    d_info = pickle.dumps(d)
 
-    l.debug("Loading!")
-    ana.set_dl(ana.DirDataLayer(pickle_dir))
-    #nose.tools.assert_equal(len(claripy.dl._cache), 0)
-
-    cc = claripy.ast.BV.ana_load(c_info)
-    nose.tools.assert_equal(str(cc), str(c))
-    cd = claripy.ast.BV.ana_load(d_info)
-    nose.tools.assert_equal(str(cd), str(d))
+    cc = pickle.loads(c_info)
+    assert str(cc) == str(c)
+    cd = pickle.loads(d_info)
+    assert str(cd) == str(d)
+    assert c.args[0] is d.args[0]
 
     l.debug("Time to test some solvers!")
     s = claripy.Solver()
     x = claripy.BVS("x", 32)
     s.add(x == 3)
     s.finalize()
-    ss = claripy.Solver.ana_load(s.ana_store())
-    nose.tools.assert_equal(str(s.constraints), str(ss.constraints))
-    nose.tools.assert_equal(str(s.variables), str(ss.variables))
+    ss = pickle.loads(pickle.dumps(s))
+    assert str(s.constraints) == str(ss.constraints)
+    assert str(s.variables) == str(ss.variables)
 
     s = claripy.SolverComposite()
     x = claripy.BVS("x", 32)
     s.add(x == 3)
     s.finalize()
-    ss = claripy.SolverComposite.ana_load(s.ana_store())
+    ss = pickle.loads(pickle.dumps(s))
     old_constraint_sets = [[hash(j) for j in k.constraints] for k in s._solver_list]
     new_constraint_sets = [[hash(j) for j in k.constraints] for k in ss._solver_list]
-    nose.tools.assert_equal(old_constraint_sets, new_constraint_sets)
-    nose.tools.assert_equal(str(s.variables), str(ss.variables))
+    assert old_constraint_sets == new_constraint_sets
+    assert str(s.variables) == str(ss.variables)
 
 if __name__ == '__main__':
     test_pickle_ast()
     test_pickle_frontend()
-    test_datalayer()
+    test_identity()


### PR DESCRIPTION
What does this mean for you?

- ANA is gone
- AST deduplication still happens, as normal, in `claripy.ast.Base.__new__`
- For single pickles, this does not matter. Pickle handles all deduplication internally.
- For multiple pickles, the user is expected to provide the deduplication solution. One such (first step) is the stuff in `angr.vaults`.

Opening this PR for tomorrow's festivities.