### PR TITLE
Let flattening simplifiers evaluate multiple concrete args together

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -615,7 +615,7 @@ class Base:
     # Various AST modifications (replacements)
     #
 
-    def swap_args(self, new_args, new_length=None, simplify=False):
+    def swap_args(self, new_args, new_length=None, **kwargs):
         """
         This returns the same AST, with the arguments swapped out for new_args.
         """
@@ -626,7 +626,7 @@ class Base:
         #symbolic = any(a.symbolic for a in new_args if isinstance(a, Base))
         #variables = frozenset.union(frozenset(), *(a.variables for a in new_args if isinstance(a, Base)))
         length = self.length if new_length is None else new_length
-        a = self.make_like(self.op, new_args, length=length, simplify=simplify)
+        a = self.make_like(self.op, new_args, length=length, **kwargs)
         #if a.op != self.op or a.symbolic != self.symbolic or a.variables != self.variables:
         #   raise ClaripyOperationError("major bug in swap_args()")
         return a

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -615,7 +615,7 @@ class Base:
     # Various AST modifications (replacements)
     #
 
-    def swap_args(self, new_args, new_length=None):
+    def swap_args(self, new_args, new_length=None, simplify=False):
         """
         This returns the same AST, with the arguments swapped out for new_args.
         """
@@ -626,7 +626,7 @@ class Base:
         #symbolic = any(a.symbolic for a in new_args if isinstance(a, Base))
         #variables = frozenset.union(frozenset(), *(a.variables for a in new_args if isinstance(a, Base)))
         length = self.length if new_length is None else new_length
-        a = self.__class__(self.op, new_args, length=length)
+        a = self.make_like(self.op, new_args, length=length, simplify=simplify)
         #if a.op != self.op or a.symbolic != self.symbolic or a.variables != self.variables:
         #   raise ClaripyOperationError("major bug in swap_args()")
         return a
@@ -891,7 +891,7 @@ class Base:
 
                     elif ite_args.count(True) == 0:
                         # if there are no ifs that came to the surface, there's nothing more to do
-                        excavated = op.swap_args(args)
+                        excavated = op.swap_args(args, simplify=True)
 
                     else:
                         # this gets called when we're *not* in an If, but there are Ifs in the args.
@@ -912,12 +912,12 @@ class Base:
                                 new_false_args.append(a.args[1])
                             else:
                                 # weird conditions -- giving up!
-                                excavated = op.swap_args(args)
+                                excavated = op.swap_args(args, simplify=True)
                                 break
 
                         else:
-                            excavated = If(cond, op.swap_args(new_true_args),
-                                           op.swap_args(new_false_args))
+                            excavated = If(cond, op.swap_args(new_true_args, simplify=True),
+                                           op.swap_args(new_false_args, simplify=True))
 
                     # continue
                     arg_queue.append(excavated)

--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -447,7 +447,7 @@ class SimplificationManager:
 
     @staticmethod
     def bitwise_add_simplifier(*args):
-        return SimplificationManager._flatten_simplifier('__add__', lambda new_args: tuple(a for a in new_args if a.op != 'BVV' or a.args[0] != 0), *args)
+        return SimplificationManager._flatten_simplifier('__add__', lambda new_args: tuple(a for a in new_args if a.op != 'BVV' or a.args[0] != 0), *args, initial_value=ast.all_operations.BVV(0, len(args[0])))
 
     @staticmethod
     def bitwise_mul_simplifier(*args):

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -106,6 +106,12 @@ def perf_boolean_and_simplification_1():
         else:
             v = claripy.And(v, bool_vars[i])
 
+def test_concrete_flatten():
+    a = claripy.BVS('a', 32)
+    b = a + 10
+    c = 10 + b
+    nose.tools.assert_is(c, a + 20)
+
 
 def perf():
     import timeit
@@ -123,3 +129,4 @@ if __name__ == '__main__':
     test_rotate_shift_mask_simplification()
     test_reverse_extract_reverse_simplification()
     test_reverse_concat_reverse_simplification()
+    test_concrete_flatten()


### PR DESCRIPTION
requires running simplifications during ite excavation to get tests to pass, but honestly that's not too bad of a deal tbh