### PR TITLE
Add more fast paths.

### DIFF
--- a/claripy/backends/backend_concrete.py
+++ b/claripy/backends/backend_concrete.py
@@ -73,11 +73,7 @@ class BackendConcrete(Backend):
         """
         if type(expr) is BV:
             if expr.op == "BVV":
-                cached_obj = self._object_cache.get(expr._cache_key, None)
-                if cached_obj is None:
-                    cached_obj = self.BVV(*expr.args)
-                    self._object_cache[expr._cache_key] = cached_obj
-                return cached_obj
+                return self.BVV(*expr.args)
         if type(expr) is Bool and expr.op == "BoolV":
             return expr.args[0]
         return super().convert(expr)

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -72,6 +72,11 @@ def _handle_annotations(simp, args):
         return None
 
     ast_args = tuple(a for a in args if isinstance(a, ast.Base))
+
+    # fast path: return simp if no annotations exist
+    if not any(a.annotations for a in ast_args):
+        return simp
+
     preserved_relocatable = frozenset(simp._relocatable_annotations)
     relocated_annotations = set()
     bad_eliminated = 0


### PR DESCRIPTION
- Don't cache BVVs. Just create them instead. It's faster.
- BVVs don't support annotations any more.
- Run eager evaluation on concrete operations sooner.
- If no annotations exist, return sooner.