### PR TITLE
Cache abstraction info for constraints when tracking is enabled

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -691,6 +691,15 @@ class BackendZ3(Backend):
         else:
             s.add(*c)
 
+    def add(self, s, c, track=False):
+        converted = self.convert_list(c)
+        if track:
+            for a, nice_ast in zip(c, converted):
+                ast = nice_ast.ast
+                h = self._z3_ast_hash(ast)
+                self._ast_cache[h] = (a, ast)
+        return self._add(s, converted, track=track)
+
     def _unsat_core(self, s):
         cores = s.unsat_core()
         constraints = [ ]


### PR DESCRIPTION
Otherwise, we will try to abstract z3's normalized version of the constraints. This is undesirable for my usecase.