### PR TITLE
Implement operations from ast/strings.py in the z3 backend

### DIFF
--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -154,6 +154,7 @@ StrIndexOf = operations.op("StrIndexOf", (String, String, BV, int), BV, calc_len
 StrToInt = operations.op("StrToInt", (String, int), BV, calc_length=operations.strtoint_bv_size_calc, bound=False)
 IntToStr = operations.op("IntToStr", BV, String, calc_length=operations.int_to_str_length_calc, bound=False)
 StrIsDigit = operations.op("StrIsDigit", String, Bool, bound=False)
+UnitStr = operations.op("UnitStr", BV, String, bound=False) # convert BV to single-char string
 
 # Equality / inequality check
 String.__eq__ = operations.op('__eq__', (String, String), Bool)
@@ -173,3 +174,4 @@ String.StrIndexOf = staticmethod(StrIndexOf)
 String.StrToInt = staticmethod(StrToInt)
 String.StrIsDigit = staticmethod(StrIsDigit)
 String.IntToStr = staticmethod(IntToStr)
+String.UnitStr = staticmethod(UnitStr)

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -152,9 +152,9 @@ StrPrefixOf = operations.op("StrPrefixOf", (String, String), Bool, bound=False)
 StrSuffixOf = operations.op("StrSuffixOf", (String, String), Bool, bound=False)
 StrIndexOf = operations.op("StrIndexOf", (String, String, BV, int), BV, calc_length=operations.strindexof_bv_size_calc, bound=False)
 StrToInt = operations.op("StrToInt", (String, int), BV, calc_length=operations.strtoint_bv_size_calc, bound=False)
-IntToStr = operations.op("IntToStr", BV, String, calc_length=operations.int_to_str_length_calc, bound=False)
-StrIsDigit = operations.op("StrIsDigit", String, Bool, bound=False)
-UnitStr = operations.op("UnitStr", BV, String, bound=False) # convert BV to single-char string
+IntToStr = operations.op("IntToStr", (BV,), String, calc_length=operations.int_to_str_length_calc, bound=False)
+StrIsDigit = operations.op("StrIsDigit", (String,), Bool, bound=False)
+UnitStr = operations.op("UnitStr", (BV,), String, bound=False) # convert BV to single-char string
 
 # Equality / inequality check
 String.__eq__ = operations.op('__eq__', (String, String), Bool)

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -59,7 +59,10 @@ class String(Bits):
     def _from_BV(like, value): # pylint: disable=unused-argument
         return value
 
-
+    @staticmethod
+    def _from_str(like, value):
+        return StringV(value)
+    
     def strReplace(self, str_to_replace, replacement):
         """
         Replace the first occurence of str_to_replace with replacement

--- a/claripy/backends/backend_concrete.py
+++ b/claripy/backends/backend_concrete.py
@@ -142,6 +142,8 @@ class BackendConcrete(Backend):
             return expr.value
         elif isinstance(expr, fp.FPV):
             return expr.value
+        elif isinstance(expr, strings.StringV):
+            return expr.value
         elif isinstance(expr, bool):
             return expr
         elif isinstance(expr, numbers.Number):

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -161,6 +161,7 @@ class BackendZ3(Backend):
         self._op_raw['StrSubstr'] = self._op_raw_StrSubstr
         self._op_raw['StrExtract'] = self._op_raw_StrExtract
         self._op_raw['StrLen'] = self._op_raw_StrLen
+        self._op_raw['StrReplace'] = self._op_raw_StrReplace
         self._op_raw['StrContains'] = self._op_raw_StrContains
         self._op_raw['StrPrefixOf'] = self._op_raw_StrPrefixOf
         self._op_raw['StrSuffixOf'] = self._op_raw_StrSuffixOf
@@ -1340,6 +1341,11 @@ class BackendZ3(Backend):
     @condom
     def _op_raw_StrLen(input_string, bitlength):
         return z3.Int2BV(z3.Length(input_string), bitlength)
+
+    @staticmethod
+    @condom
+    def _op_raw_StrReplace(input_string, target, replacement):
+        return z3.Replace(input_string, target, replacement)
 
     @staticmethod
     @condom

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -122,6 +122,7 @@ class BackendZ3(Backend):
 
         # and the operations
         all_ops = backend_fp_operations | backend_operations if supports_fp else backend_operations
+        all_ops |= backend_strings_operations - {'StrIsDigit'} 
         for o in all_ops - {'BVV', 'BoolV', 'FPV', 'FPS', 'BitVec', 'StringV'}:
             self._op_raw[o] = getattr(self, '_op_raw_' + o)
         self._op_raw['Xor'] = self._op_raw_Xor
@@ -155,20 +156,6 @@ class BackendZ3(Backend):
         self._op_raw['__or__'] = self._op_or
         self._op_raw['__xor__'] = self._op_xor
         self._op_raw['__and__'] = self._op_and
-
-        # String operations
-        self._op_raw['StrConcat'] = self._op_raw_StrConcat
-        self._op_raw['StrSubstr'] = self._op_raw_StrSubstr
-        self._op_raw['StrExtract'] = self._op_raw_StrExtract
-        self._op_raw['StrLen'] = self._op_raw_StrLen
-        self._op_raw['StrReplace'] = self._op_raw_StrReplace
-        self._op_raw['StrContains'] = self._op_raw_StrContains
-        self._op_raw['StrPrefixOf'] = self._op_raw_StrPrefixOf
-        self._op_raw['StrSuffixOf'] = self._op_raw_StrSuffixOf
-        self._op_raw['StrIndexOf'] = self._op_raw_StrIndexOf
-        self._op_raw['StrToInt'] = self._op_raw_StrToInt
-        self._op_raw['IntToStr'] = self._op_raw_IntToStr     
-        self._op_raw['UnitStr'] = self._op_raw_UnitStr 
 
     # XXX this is a HUGE HACK that should be removed whenever uninitialized gets moved to the
     # "proposed annotation backend" or wherever will prevent it from being part of the object
@@ -1372,8 +1359,8 @@ class BackendZ3(Backend):
 
     @staticmethod
     @condom
-    def _op_raw_StrToInt(input_string):
-        return z3.StrToInt(input_string)
+    def _op_raw_StrToInt(input_string, bitlength):
+        return z3.Int2BV(z3.StrToInt(input_string), bitlength)
 
     @staticmethod
     @condom
@@ -1544,7 +1531,7 @@ from ..ast.bv import BV, BVV
 from ..ast.bool import BoolV, Bool
 from ..ast.fp import FP, FPV
 from ..ast.strings import StringV, StringS
-from ..operations import backend_operations, backend_fp_operations
+from ..operations import backend_operations, backend_fp_operations, backend_strings_operations
 from ..fp import FSort, RM, RM_NearestTiesEven, RM_NearestTiesAwayFromZero, RM_TowardsPositiveInf, RM_TowardsNegativeInf, RM_TowardsZero
 from ..errors import ClaripyError, BackendError, ClaripyOperationError
 from .. import _all_operations

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1412,7 +1412,7 @@ op_map = {
     'Z3_OP_ADD': '__add__',
     'Z3_OP_SUB': '__sub__',
     'Z3_OP_UMINUS': '__neg__',
-    'Z3_OP_MUL': '__mul__', # TODO: convert to python bytearray
+    'Z3_OP_MUL': '__mul__',
     'Z3_OP_DIV': 'SDiv',
     'Z3_OP_IDIV': 'SDiv',
     'Z3_OP_REM': '__mod__',

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -597,7 +597,8 @@ class BackendZ3(Backend):
                 assert(z3.Z3_get_decl_parameter_kind(ctx, decl, 0) == z3.Z3_PK_SYMBOL)
                 symb = z3.Z3_get_decl_symbol_parameter(ctx, decl, 0)
                 assert(z3.Z3_get_symbol_kind(ctx, symb) == z3.Z3_STRING_SYMBOL)
-                return z3.Z3_get_symbol_string(ctx, symb)
+                return z3.Z3_get_symbol_string(ctx, symb).encode().decode('unicode_escape').encode()
+                # see https://stackoverflow.com/a/58829514/3154996
             except AssertionError:
                 raise BackendError("Weird z3 model")
         else:
@@ -1346,7 +1347,7 @@ op_map = {
     'Z3_OP_ADD': '__add__',
     'Z3_OP_SUB': '__sub__',
     'Z3_OP_UMINUS': '__neg__',
-    'Z3_OP_MUL': '__mul__',
+    'Z3_OP_MUL': '__mul__', # TODO: convert to python bytearray
     'Z3_OP_DIV': 'SDiv',
     'Z3_OP_IDIV': 'SDiv',
     'Z3_OP_REM': '__mod__',

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -157,7 +157,18 @@ class BackendZ3(Backend):
         self._op_raw['__and__'] = self._op_and
 
         # String operations
+        self._op_raw['StrConcat'] = self._op_raw_StrConcat
+        self._op_raw['StrSubstr'] = self._op_raw_StrSubstr
+        self._op_raw['StrExtract'] = self._op_raw_StrExtract
+        self._op_raw['StrReplace'] = self._op_raw_StrReplace
+        self._op_raw['StrLen'] = self._op_raw_StrLen
+        self._op_raw['StrContains'] = self._op_Raw_StrContains
+        self._op_raw['StrPrefixOf'] = self._op_raw_StrPrefixOf
+        self._op_raw['StrSuffixOf'] = self._op_raw_StrSuffixOf
         self._op_raw['StrIndexOf'] = self._op_raw_StrIndexOf
+        self._op_raw['StrToInt'] = self._op_raw_StrToInt
+        self._op_raw['StrIsDigit'] = self._op_raw_StrIsDigit
+        self._op_raw['IntToStr'] = self._op_raw_IntToStr      
 
     # XXX this is a HUGE HACK that should be removed whenever uninitialized gets moved to the
     # "proposed annotation backend" or wherever will prevent it from being part of the object
@@ -1305,6 +1316,47 @@ class BackendZ3(Backend):
     def _identical(self, a, b):
         return a.eq(b)
 
+    # String operations:
+
+    @staticmethod
+    @condom
+    def _op_raw_StrConcat(*args):
+        return z3.Concat(*args)
+
+    @staticmethod
+    @condom
+    def _op_raw_StrSubstr(start_idx, count, initial_string):
+        return z3.SubString(
+            initial_string,
+            z3.BV2Int(start_idx),
+            z3.BV2Int(count)
+        )
+
+    @staticmethod
+    @condom
+    def _op_raw_StrExtract(high, low, str_val):
+        return z3.SubString(str_val, low, high + 1 - low)
+
+    @staticmethod
+    @condom
+    def _op_raw_StrLen(input_string, bitlength):
+        return z3.Int2BV(z3.Length(input_string), bitlength)
+
+    @staticmethod
+    @condom
+    def _op_raw_StrContains(input_string, substring):
+        return z3.Contains(input_string, substring)
+
+    @staticmethod
+    @condom
+    def _op_raw_StrPrefixOf(prefix, input_string):
+        return z3.PrefixOf(prefix, input_string)
+
+    @staticmethod
+    @condom
+    def _op_raw_StrSuffixOf(suffix, input_string):
+        return z3.SuffixOf(suffix, input_string)
+
     @staticmethod
     @condom
     def _op_raw_StrIndexOf(string, pattern, start_idx, bitlength):
@@ -1312,7 +1364,21 @@ class BackendZ3(Backend):
             z3.IndexOf(string, pattern, z3.BV2Int(start_idx)),
             bitlength
         )
- 
+
+    @staticmethod
+    @condom
+    def _op_raw_StrToInt(input_string):
+        return z3.StrToInt(input_string)
+
+    @staticmethod
+    @condom
+    def _op_raw_IntToStr(input_bvv):
+        return z3.IntToStr(z3.BV2Int(input_bvv))
+
+    @staticmethod
+    @condom
+    def _op_raw_UnitStr(input_bvv):
+        return z3.Unit(input_bvv)
 #
 # this is for the actual->abstract conversion above
 #

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1294,7 +1294,7 @@ class BackendZ3(Backend):
     @condom
     def _op_raw_SGE(a, b):
         return a >= b
-        
+
     @staticmethod
     @condom
     def _op_raw_SDiv(a, b):

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -160,15 +160,14 @@ class BackendZ3(Backend):
         self._op_raw['StrConcat'] = self._op_raw_StrConcat
         self._op_raw['StrSubstr'] = self._op_raw_StrSubstr
         self._op_raw['StrExtract'] = self._op_raw_StrExtract
-        self._op_raw['StrReplace'] = self._op_raw_StrReplace
         self._op_raw['StrLen'] = self._op_raw_StrLen
-        self._op_raw['StrContains'] = self._op_Raw_StrContains
+        self._op_raw['StrContains'] = self._op_raw_StrContains
         self._op_raw['StrPrefixOf'] = self._op_raw_StrPrefixOf
         self._op_raw['StrSuffixOf'] = self._op_raw_StrSuffixOf
         self._op_raw['StrIndexOf'] = self._op_raw_StrIndexOf
         self._op_raw['StrToInt'] = self._op_raw_StrToInt
-        self._op_raw['StrIsDigit'] = self._op_raw_StrIsDigit
-        self._op_raw['IntToStr'] = self._op_raw_IntToStr      
+        self._op_raw['IntToStr'] = self._op_raw_IntToStr     
+        self._op_raw['UnitStr'] = self._op_raw_UnitStr 
 
     # XXX this is a HUGE HACK that should be removed whenever uninitialized gets moved to the
     # "proposed annotation backend" or wherever will prevent it from being part of the object

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -607,7 +607,7 @@ class BackendZ3(Backend):
                 assert(z3.Z3_get_decl_parameter_kind(ctx, decl, 0) == z3.Z3_PK_SYMBOL)
                 symb = z3.Z3_get_decl_symbol_parameter(ctx, decl, 0)
                 assert(z3.Z3_get_symbol_kind(ctx, symb) == z3.Z3_STRING_SYMBOL)
-                return z3.Z3_get_symbol_string(ctx, symb).encode().decode('unicode_escape').encode()
+                return z3.Z3_get_symbol_string(ctx, symb).encode().decode('unicode_escape')
                 # see https://stackoverflow.com/a/58829514/3154996
             except AssertionError:
                 raise BackendError("Weird z3 model")

--- a/claripy/frontend_mixins/model_cache_mixin.py
+++ b/claripy/frontend_mixins/model_cache_mixin.py
@@ -46,6 +46,7 @@ class ModelCache:
             all_operations.BVV(self.model.get(a.args[0], 0), a.length) if a.op == 'BVS' else
             all_operations.BoolV(self.model.get(a.args[0], True)) if a.op == 'BoolS' else
             all_operations.FPV(self.model.get(a.args[0], 0.0), a.args[1]) if a.op == 'FPS' else
+            all_operations.StringV(self.model.get(a.args[0], "")) if a.op == 'StringS' else
             a
         )
 

--- a/claripy/strings.py
+++ b/claripy/strings.py
@@ -5,7 +5,7 @@ from .bv import BVV
 
 class StringV(BackendObject):
     def __init__(self, value):
-        self.value = bytes(value)
+        self.value = value 
 
     def __repr__(self):
         return 'StringV(%s)' % (self.value)

--- a/claripy/strings.py
+++ b/claripy/strings.py
@@ -5,7 +5,7 @@ from .bv import BVV
 
 class StringV(BackendObject):
     def __init__(self, value):
-        self.value = value
+        self.value = bytes(value)
 
     def __repr__(self):
         return 'StringV(%s)' % (self.value)

--- a/claripy/strings.py
+++ b/claripy/strings.py
@@ -5,7 +5,7 @@ from .bv import BVV
 
 class StringV(BackendObject):
     def __init__(self, value):
-        self.value = value 
+        self.value = value
 
     def __repr__(self):
         return 'StringV(%s)' % (self.value)


### PR DESCRIPTION
This patch implements all the claripy string operations (except IsDigit) in the z3 backend. It also adds a new string operation, UnitStr, which creates a single-char string from a bitvector. I am using this code for experiments with making the simprocedures for `<string.h>` functions faster by passing constraints to z3's powerful string solver, `z3str3`. Any feedback on the changes would be welcome. This is my first PR to claripy, so apologies in advance for any errors or misunderstandings :)

Edit: I have tested `StrIndexOf` with `StringS` and `StringV` values on my machine and it works fine (that's the main operation I need for my work in angr). The other operations have not been tested, but should work based on how similar their implementations are to `StrIndexOf`. If anyone is actually interested in using the other functions, I'd be happy to write unit tests for all of them.

Edit: It should also be noted that my code uses z3's definition of a string as a sequence of 8-bit BVs. If BVs of different width are used much of the code will work fine, but some weird errors may crop up. In particular this will limit the usage of the code for wide-char variants of `<string.h>` functions.