### PR TITLE
Make composite solver more efficient in the presence of many independent constraint sets

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -607,6 +607,10 @@ def test_composite_solver_branching_optimizations():
     assert len(s._unchecked_solvers) == 1
     assert len(s2._unchecked_solvers) == 0
 
+    s2.add(z == 12)
+    assert not s2.satisfiable()
+    assert not s2.satisfiable()
+
 
 if __name__ == '__main__':
     for fparams in test_unsat_core():


### PR DESCRIPTION
Until now, the composite solver would loop through all of its children to check if it is satisfiable. Even if each check hit the child's cache, looping through the children would make this process slow. Now, the composite solver will only check solvers that it does not already know to be satisfiable.

One specific side-effect of this is that if someone accesses the children directly, and adds constraints to them, the composite solver won't know to re-check. There were already other parts of the composite solver that would break in that scenario, though, so I think that's okay.