### PR TITLE
fix missing extra_constraints in CompositeFrontend.unsat_core()

### DIFF
--- a/claripy/frontends/composite_frontend.py
+++ b/claripy/frontends/composite_frontend.py
@@ -365,7 +365,7 @@ class CompositeFrontend(ConstrainedFrontend):
         cores = [ ]
 
         for solver in self._solver_list:
-            cores.extend(list(solver.unsat_core()))
+            cores.extend(list(solver.unsat_core(extra_constraints=extra_constraints)))
 
         return cores
 


### PR DESCRIPTION
In the CompositeFrontend.unsat_core function, extra_constraints was not passed to child solvers. Therefore it cannot get an unsat core if it's the extra_constraints causing the unsatisfiability.