### PR TITLE
measure twice, split once

### DIFF
--- a/claripy/frontends/composite_frontend.py
+++ b/claripy/frontends/composite_frontend.py
@@ -182,7 +182,7 @@ class CompositeFrontend(ConstrainedFrontend):
             old_solvers = self._solvers_for_variables(s.variables)
             if len(new_solvers) == len(old_solvers):
                 done = set()
-                for ss in s.split():
+                for ss in new_solvers:
                     if ss in done:
                         continue
                     done.add(ss)


### PR DESCRIPTION
For some reason, the old code would split a solver twice while reabsorbing it. This can be a costly procedure, so let's do it once.