### PR TITLE
Change ite_dict to use binary search tree

### DIFF
--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -165,7 +165,7 @@ def is_false(e, exact=None): #pylint:disable=unused-argument
 #This improves Z3 search capability (eliminating branches) and decreases recursion depth:
 #linear search trees make Z3 error out on tables larger than a couple hundred elements.)
 def ite_dict(i, d, default):
-    
+
     """
     Return an expression of if-then-else trees which expresses a switch tree
     :param i: The variable which may take on multiple values affecting the final result
@@ -174,21 +174,21 @@ def ite_dict(i, d, default):
     :return: An expression encoding the result of the above
     """
     i = i.ast if type(i) is ASTCacheKey else i
-    
+
     #for small dicts fall back to the linear implementation
     if len(d) < 4:
         return ite_cases([ (i == c, v) for c,v in d.items() ], default)
-    
+
     #otherwise, binary search.
     #Find the median:
     keys = list(d.keys())
     keys.sort()
     split_val = keys[len(keys)//2]
-    
+
     #split the dictionary
     dictLow = {c:v for c,v in d.items() if c <= split_val}
     dictHigh = {c:v for c,v in d.items() if c > split_val}
-    
+
     valLow = ite_dict(i, dictLow, default)
     valHigh = ite_dict(i, dictHigh, default)
     return If(i <= split_val, valLow, valHigh)

--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -164,26 +164,34 @@ def is_false(e, exact=None): #pylint:disable=unused-argument
 #For large tables, ite_dict that uses a binary search tree instead of a "linear" search tree.
 #This improves Z3 search capability (eliminating branches) and decreases recursion depth:
 #linear search trees make Z3 error out on tables larger than a couple hundred elements.)
-def ite_dict(i, d, default):	
-	i = i.ast if type(i) is ASTCacheKey else i
-	
-	#for small dicts fall back to the linear implementation
-	if len(d) < 4:
-		return ite_cases([ (i == c, v) for c,v in d.items() ], default)
-	
-	#otherwise, binary search.
-	#Find the median:
-	keys = list(d.keys())
-	keys.sort()
-	split_val = keys[len(keys)//2]
-	
-	#split the dictionary
-	dictLow = {c:v for c,v in d.items() if c <= split_val}
-	dictHigh = {c:v for c,v in d.items() if c > split_val}
-	
-	valLow = ite_dict(i, dictLow, default)
-	valHigh = ite_dict(i, dictHigh, default)
-	return If(i <= split_val, valLow, valHigh)
+def ite_dict(i, d, default):
+    
+    """
+    Return an expression of if-then-else trees which expresses a switch tree
+    :param i: The variable which may take on multiple values affecting the final result
+    :param d: A dict mapping possible values for i to values which the result could be
+    :param default: A default value that the expression should take on if `i` matches none of the keys of `d`
+    :return: An expression encoding the result of the above
+    """
+    i = i.ast if type(i) is ASTCacheKey else i
+    
+    #for small dicts fall back to the linear implementation
+    if len(d) < 4:
+        return ite_cases([ (i == c, v) for c,v in d.items() ], default)
+    
+    #otherwise, binary search.
+    #Find the median:
+    keys = list(d.keys())
+    keys.sort()
+    split_val = keys[len(keys)//2]
+    
+    #split the dictionary
+    dictLow = {c:v for c,v in d.items() if c <= split_val}
+    dictHigh = {c:v for c,v in d.items() if c > split_val}
+    
+    valLow = ite_dict(i, dictLow, default)
+    valHigh = ite_dict(i, dictHigh, default)
+    return If(i <= split_val, valLow, valHigh)
 
 def ite_cases(cases, default):
     """


### PR DESCRIPTION
Currently, `ite_dict` turns a dictionary lookup into a claripy expression by using a linear series of if-then-else statements. This creates expression trees whose depths are equal to the size of the dict. For a dict with, say, 200 elements, this creates a RecursionError in claripy. This came up recently for me when [hooking an instruction that was most easily implemented by a table](https://ohaithe.re/post/624142953693249536/uiuctf-2020-cricket32) of 256 elements, and claripy crashed.

This PR replaces `ite_dict` to use a binary search tree when the dict gets biggish. It would be risky to do this for `ite_cases`, since there they might be an assumption that it tries the cases in the given order, in the event that two cases are both true. But for a dict, only one case can be true, so this binary searching won't change the functionality.