### PR TITLE
Ideally, simplifiers should not change sizes of sub expressions.

### DIFF
--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -906,6 +906,9 @@ class SimplificationManager:
                             return op(a_arg0[b_highbit_idx : 0], b_lower)
                         else:
                             # nope
+                            if b_highbit_idx == b.size() - 1:
+                                # no change is happening
+                                return None
                             return op(a_arg0[b_highbit_idx : 0] & a_arg1.args[0], b_lower)
                     elif b_higher_bits_are_0 is False:
                         return ast.all_operations.false if op is operator.__eq__ else ast.all_operations.true

--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -895,13 +895,12 @@ class SimplificationManager:
 
                     if b_higher_bits_are_0 is True:
                         # extra check: can we get rid of the mask
-                        b_lower = b[b.size() - 1 - zero_bits: 0]
                         if mask_allones:
                             # yes!
-                            return op(a_arg0[b.size() - 1 - zero_bits : 0], b_lower)
+                            return op(a_arg0, b)
                         else:
                             # nope
-                            return op(a_arg0[b.size() - 1 - zero_bits: 0] & a_arg1.args[0], b_lower)
+                            return None
                     elif b_higher_bits_are_0 is False:
                         return ast.all_operations.false if op is operator.__eq__ else ast.all_operations.true
 

--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -899,7 +899,7 @@ class SimplificationManager:
                         if b.size() % 8 == 0:
                             # originally, b was 8-bit aligned. Can we keep the size of the new expression 8-byte aligned?
                             if (b_highbit_idx + 1) % 8 != 0:
-                                b_highbit_idx += (b_highbit_idx + 1) % 8
+                                b_highbit_idx += 8 - (b_highbit_idx + 1) % 8
                         b_lower = b[b_highbit_idx : 0]
                         if mask_allones:
                             # yes!

--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -895,12 +895,18 @@ class SimplificationManager:
 
                     if b_higher_bits_are_0 is True:
                         # extra check: can we get rid of the mask
+                        b_highbit_idx = b.size() - 1 - zero_bits
+                        if b.size() % 8 == 0:
+                            # originally, b was 8-bit aligned. Can we keep the size of the new expression 8-byte aligned?
+                            if (b_highbit_idx + 1) % 8 != 0:
+                                b_highbit_idx += (b_highbit_idx + 1) % 8
+                        b_lower = b[b_highbit_idx : 0]
                         if mask_allones:
                             # yes!
-                            return op(a_arg0, b)
+                            return op(a_arg0[b_highbit_idx : 0], b_lower)
                         else:
                             # nope
-                            return None
+                            return op(a_arg0[b_highbit_idx : 0] & a_arg1.args[0], b_lower)
                     elif b_higher_bits_are_0 is False:
                         return ast.all_operations.false if op is operator.__eq__ else ast.all_operations.true
 

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -164,7 +164,7 @@ def test_mask_eq_constant():
 
     assert expr.op == "__eq__"
     assert expr.args[0].op == "__and__"
-    arg0, arg1 = expr.args[0].args
+    _, arg1 = expr.args[0].args
     assert arg1.size() == 16
     assert arg1.args[0] == 0x1fff
 
@@ -231,7 +231,7 @@ def test_zeroext_extract_comparing_against_constant_simplifier():
 
 
 def perf():
-    import timeit
+    import timeit  # pylint:disable=import-outside-toplevel
     print(timeit.timeit("perf_boolean_and_simplification_0()",
                         number=10,
                         setup="from __main__ import perf_boolean_and_simplification_0"))

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -148,6 +148,26 @@ def test_mask_eq_constant():
     assert expr.args[0].args[2] is a
     assert expr.args[1].op == "BVV" and expr.args[1].args == (0, 1)
 
+    # the highest bit of the mask (0x1fff) is not aligned to 8
+    # we want the mask to be BVV(16, 0x1fff) instead of BVV(13, 0x1fff)
+    a = claripy.BVS("sim_data", 8, explicit_name=True)
+    expr = (claripy.ZeroExt(
+        48,
+        claripy.Extract(
+            15,
+            0,
+            claripy.Concat(
+                claripy.BVV(0, 63),
+                a[0:0]
+            )
+        )) & 0x1fff) == 0x0
+
+    assert expr.op == "__eq__"
+    assert expr.args[0].op == "__and__"
+    arg0, arg1 = expr.args[0].args
+    assert arg1.size() == 16
+    assert arg1.args[0] == 0x1fff
+
 
 def test_and_mask_comparing_against_constant_simplifier():
 

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -147,8 +147,6 @@ def test_mask_eq_constant():
     assert expr.args[0].args[0] == 0 and expr.args[0].args[1] == 0
     assert expr.args[0].args[2] is a
     assert expr.args[1].op == "BVV" and expr.args[1].args == (0, 1)
-    assert expr.op == "__eq__"
-    assert expr.args[0].op == "Extract"
 
 
 def test_and_mask_comparing_against_constant_simplifier():


### PR DESCRIPTION
Otherwise it makes static analysis (especially decompiler) confused when it generates code like `Extract(10, 0, some_expr)`, since extracting 11 bits and creating a new 11-bit expression cannot be easily modeled in C code.