### PR TITLE
Remove all `__div__` uses from claripy

### DIFF
--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -84,7 +84,7 @@ class BV(Bits):
             raise ValueError("Incorrect index %d. Your index must be between %d and %d." % (
                 index, 0, self.size() // 8 - 1
             ))
-        BV: r = self[min(pos * 8 + 7, self.size() - 1) : pos * 8]
+        r: BV = self[min(pos * 8 + 7, self.size() - 1) : pos * 8]
         if r.size() % 8 != 0:
             r = r.zero_extend(8 - r.size() % 8)
         return r
@@ -104,7 +104,7 @@ class BV(Bits):
             ))
         if size == 0:
             return BVV(0, 0)
-        BV: r = self[min(pos * 8 + 7, self.size() - 1) : (pos - size + 1) * 8]
+        r: BV = self[min(pos * 8 + 7, self.size() - 1) : (pos - size + 1) * 8]
         if r.size() % 8 != 0:
             r = r.zero_extend(8 - r.size() % 8)
         return r

--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -85,8 +85,8 @@ class BV(Bits):
                 index, 0, self.size() // 8 - 1
             ))
         r = self[min(pos * 8 + 7, self.size() - 1) : pos * 8]
-        if r.size() % 8 != 0:
-            r = r.zero_extend(8 - r.size() % 8)
+        if r.size() % 8 != 0: #pylint:disable=no-member
+            r = r.zero_extend(8 - r.size() % 8) #pylint:disable=no-member
         return r
 
     def get_bytes(self, index, size):
@@ -105,8 +105,8 @@ class BV(Bits):
         if size == 0:
             return BVV(0, 0)
         r = self[min(pos * 8 + 7, self.size() - 1) : (pos - size + 1) * 8]
-        if r.size() % 8 != 0:
-            r = r.zero_extend(8 - r.size() % 8)
+        if r.size() % 8 != 0: #pylint:disable=no-member
+            r = r.zero_extend(8 - r.size() % 8) #pylint:disable=no-member
         return r
 
     def zero_extend(self, n):

--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -84,7 +84,7 @@ class BV(Bits):
             raise ValueError("Incorrect index %d. Your index must be between %d and %d." % (
                 index, 0, self.size() // 8 - 1
             ))
-        r = self[min(pos * 8 + 7, self.size() - 1) : pos * 8]
+        BV: r = self[min(pos * 8 + 7, self.size() - 1) : pos * 8]
         if r.size() % 8 != 0:
             r = r.zero_extend(8 - r.size() % 8)
         return r
@@ -104,7 +104,7 @@ class BV(Bits):
             ))
         if size == 0:
             return BVV(0, 0)
-        r = self[min(pos * 8 + 7, self.size() - 1) : (pos - size + 1) * 8]
+        BV: r = self[min(pos * 8 + 7, self.size() - 1) : (pos - size + 1) * 8]
         if r.size() % 8 != 0:
             r = r.zero_extend(8 - r.size() % 8)
         return r

--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -84,7 +84,7 @@ class BV(Bits):
             raise ValueError("Incorrect index %d. Your index must be between %d and %d." % (
                 index, 0, self.size() // 8 - 1
             ))
-        r: BV = self[min(pos * 8 + 7, self.size() - 1) : pos * 8]
+        r = self[min(pos * 8 + 7, self.size() - 1) : pos * 8]
         if r.size() % 8 != 0:
             r = r.zero_extend(8 - r.size() % 8)
         return r
@@ -104,7 +104,7 @@ class BV(Bits):
             ))
         if size == 0:
             return BVV(0, 0)
-        r: BV = self[min(pos * 8 + 7, self.size() - 1) : (pos - size + 1) * 8]
+        r = self[min(pos * 8 + 7, self.size() - 1) : (pos - size + 1) * 8]
         if r.size() % 8 != 0:
             r = r.zero_extend(8 - r.size() % 8)
         return r

--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -387,8 +387,6 @@ BV.__add__ = operations.op('__add__', (BV, BV), BV, extra_check=operations.lengt
 BV.__radd__ = operations.reversed_op(BV.__add__)
 BV.__floordiv__ = operations.op('__floordiv__', (BV, BV), BV, extra_check=operations.length_same_check, calc_length=operations.basic_length_calc)
 BV.__rfloordiv__ = operations.reversed_op(BV.__floordiv__)
-BV.__div__ = BV.__floordiv__
-BV.__rdiv__ = BV.__rfloordiv__
 BV.__truediv__ = BV.__floordiv__
 BV.__rtruediv__ = BV.__rfloordiv__
 BV.__mul__ = operations.op('__mul__', (BV, BV), BV, extra_check=operations.length_same_check, calc_length=operations.basic_length_calc)

--- a/claripy/ast/fp.py
+++ b/claripy/ast/fp.py
@@ -177,14 +177,12 @@ FP.__neg__ = fpNeg
 FP.__add__ = fpAdd
 FP.__sub__ = fpSub
 FP.__mul__ = fpMul
-FP.__div__ = fpDiv
 FP.__truediv__ = fpDiv
 
 FP.__radd__ = operations.reversed_op(FP.__add__)
 FP.__rsub__ = operations.reversed_op(FP.__sub__)
 FP.__rmul__ = operations.reversed_op(FP.__mul__)
-FP.__rdiv__ = operations.reversed_op(FP.__div__)
-FP.__rtruediv__ = operations.reversed_op(FP.__div__)
+FP.__rtruediv__ = operations.reversed_op(FP.__truediv__)
 
 FP.isNaN = fpIsNaN
 FP.isInf = fpIsInf

--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -156,9 +156,6 @@ class BVV(BackendObject):
             raise ClaripyZeroDivisionError()
         return BVV(o.value // self.value, self.bits)
 
-    def __rdiv__(self, o):
-        return self.__rfloordiv__(o)
-
     def __rtruediv__(self, o):
         return self.__rfloordiv__(o)
 

--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -123,9 +123,6 @@ class BVV(BackendObject):
     def __truediv__(self, other):
         return self // other # decline to implicitly have anything to do with floats
 
-    def __div__(self, other):
-        return self // other
-
     #
     # Reverse arithmetic stuff
     #

--- a/claripy/fp.py
+++ b/claripy/fp.py
@@ -195,8 +195,6 @@ class FPV(BackendObject):
             else:
                 return FPV(float('inf'), self.sort)
 
-    def __rdiv__(self, other):
-        return self.__rtruediv__(other)
     def __rfloordiv__(self, other): # decline to involve integers in this floating point process
         return self.__rtruediv__(other)
 

--- a/claripy/fp.py
+++ b/claripy/fp.py
@@ -157,8 +157,6 @@ class FPV(BackendObject):
             else:
                 return FPV(float('inf'), self.sort)
 
-    def __div__(self, other):
-        return self.__truediv__(other)
     def __floordiv__(self, other): # decline to involve integers in this floating point process
         return self.__truediv__(other)
 

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -215,7 +215,6 @@ def strtoint_bv_size_calc(s, bitlength): # pylint: disable=unused-argument
 expression_arithmetic_operations = {
     # arithmetic
     '__add__', '__radd__',
-    '__div__', '__rdiv__',
     '__truediv__', '__rtruediv__',
     '__floordiv__', '__rfloordiv__',
     '__mul__', '__rmul__',
@@ -325,7 +324,6 @@ backend_strings_operations = {
 
 opposites = {
     '__add__': '__radd__', '__radd__': '__add__',
-    '__div__': '__rdiv__', '__rdiv__': '__div__',
     '__truediv__': '__rtruediv__', '__rtruediv__': '__truediv__',
     '__floordiv__': '__rfloordiv__', '__rfloordiv__': '__floordiv__',
     '__mul__': '__rmul__', '__rmul__': '__mul__',
@@ -357,7 +355,6 @@ opposites = {
 reversed_ops = {
     '__radd__': '__add__',
     '__rand__': '__and__',
-    '__rdiv__': '__div__',
     '__rdivmod__': '__divmod__',
     '__rfloordiv__': '__floordiv__',
     '__rlshift__': '__lshift__',
@@ -401,7 +398,6 @@ infix = {
     '__add__': '+',
     '__sub__': '-',
     '__mul__': '*',
-    '__div__': '/',
     '__floordiv__': '/',
     '__truediv__': '/', # the raw / operator should use integral semantics on bitvectors
     '__pow__': '**',
@@ -455,7 +451,6 @@ op_precedence = {  # based on https://en.cppreference.com/w/c/language/operator_
 
     # precedence: 3
     '__mul__': 3,
-    '__div__': 3,
     '__floordiv__': 3,
     '__truediv__': 3, # the raw / operator should use integral semantics on bitvectors
     '__mod__': 3,

--- a/claripy/vsa/discrete_strided_interval_set.py
+++ b/claripy/vsa/discrete_strided_interval_set.py
@@ -395,8 +395,6 @@ class DiscreteStridedIntervalSet(StridedInterval):
         """
         pass
 
-    def __div__(self, o):
-        return self.__floordiv__(o)
     def __truediv__(self, o):
         return self.__floordiv__(o) # floats not welcome
 

--- a/claripy/vsa/discrete_strided_interval_set.py
+++ b/claripy/vsa/discrete_strided_interval_set.py
@@ -400,8 +400,6 @@ class DiscreteStridedIntervalSet(StridedInterval):
 
     def __rfloordiv__(self, o):
         return self.__floordiv__(o)
-    def __rdiv__(self, o):
-        return self.__rfloordiv__(o)
     def __rtruediv__(self, o):
         return self.__rfloordiv__(o)
 

--- a/claripy/vsa/strided_interval.py
+++ b/claripy/vsa/strided_interval.py
@@ -1074,8 +1074,6 @@ class StridedInterval(BackendObject):
 
         return self.udiv(o)
 
-    def __div__(self, other):
-        return self // other
     def __truediv__(self, other):
         return self // other # decline to involve floating point numbers at ALL
 

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -32,7 +32,7 @@ def test_bv():
     assert Concat(e, e, e, e) == 0b1010101010101010
     assert Concat(e,f,f) == 0b10101111
 
-    # test that __div__ is unsigned
+    # test that __truediv__ is unsigned
     assert BVV(5, 8) / BVV(254, 8) == 0
     assert SDiv(BVV(5, 8), BVV(-2, 8)) == -2
 
@@ -116,7 +116,6 @@ def test_zero_division_errors():
         except Exception as ex:  # pylint:disable=broad-except
             assert type(ex) is ClaripyZeroDivisionError
 
-    _check_exception(a, b, '__div__')
     _check_exception(a, b, '__truediv__')
     _check_exception(a, b, '__floordiv__')
     _check_exception(a, b, '__mod__')

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -119,7 +119,6 @@ def test_zero_division_errors():
     _check_exception(a, b, '__truediv__')
     _check_exception(a, b, '__floordiv__')
     _check_exception(a, b, '__mod__')
-    _check_exception(b, a, '__rdiv__')
     _check_exception(b, a, '__rtruediv__')
     _check_exception(b, a, '__rfloordiv__')
     _check_exception(b, a, '__rmod__')


### PR DESCRIPTION
`__div__` is python2. We now have `__floordiv__` and `__truediv__`. Claripy already had `__div__` simply aliasing one of the two in all use cases; these have been removed since we no longer support python2.

Related angr PR: merged