### PR TITLE
Fix/remove nonexistent ops

### DIFF
--- a/claripy/backends/backend_vsa.py
+++ b/claripy/backends/backend_vsa.py
@@ -58,9 +58,6 @@ class BackendVSA(Backend):
         self._make_expr_ops(set(expression_set_operations), op_class=self)
         self._make_raw_ops(set(backend_operations_vsa_compliant), op_module=BackendVSA)
 
-        self._op_raw['StridedInterval'] = BackendVSA.CreateStridedInterval
-        self._op_raw['ValueSet'] = ValueSet.__init__
-        self._op_raw['AbstractLocation'] = AbstractLocation.__init__
         self._op_raw['Reverse'] = BackendVSA.Reverse
         self._op_raw['If'] = self.If
         self._op_expr['BVV'] = self.BVV

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1309,6 +1309,9 @@ class BackendZ3(Backend):
     def _op_raw_SDiv(a, b):
         return a / b
 
+    def _identical(self, a, b):
+        return a.eq(b)
+
     # String operations:
 
     @staticmethod

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -133,7 +133,6 @@ class BackendZ3(Backend):
         self._op_raw['__lt__'] = self._op_raw_ULT
 
         self._op_raw['Reverse'] = self._op_raw_Reverse
-        self._op_raw['Identical'] = self._identical
         self._op_raw['fpToSBV'] = self._op_raw_fpToSBV
         self._op_raw['fpToUBV'] = self._op_raw_fpToUBV
 
@@ -1309,9 +1308,6 @@ class BackendZ3(Backend):
     @condom
     def _op_raw_SDiv(a, b):
         return a / b
-
-    def _identical(self, a, b):
-        return a.eq(b)
 
     # String operations:
 

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -295,10 +295,6 @@ backend_symbol_creation_operations = {
     'BoolS', 'BVS', 'FPS', 'StringS'
 }
 
-backend_vsa_creation_operations = {
-    'TopStridedInterval', 'StridedInterval', 'ValueSet', 'AbstractLocation'
-}
-
 backend_other_operations = { 'If' }
 
 backend_arithmetic_operations = {'SDiv', 'SMod'}
@@ -306,7 +302,7 @@ backend_arithmetic_operations = {'SDiv', 'SMod'}
 backend_operations = backend_comparator_operations | backend_bitwise_operations | backend_boolean_operations | \
                      backend_bitmod_operations | backend_creation_operations | backend_other_operations | backend_arithmetic_operations
 backend_operations_vsa_compliant = backend_bitwise_operations | backend_comparator_operations | backend_boolean_operations | backend_bitmod_operations
-backend_operations_all = backend_operations | backend_operations_vsa_compliant | backend_vsa_creation_operations
+backend_operations_all = backend_operations | backend_operations_vsa_compliant
 
 backend_fp_cmp_operations = {
     'fpLT', 'fpLEQ', 'fpGT', 'fpGEQ', 'fpEQ',
@@ -384,7 +380,7 @@ inverse_operations = {
     'SLE': 'SGT', 'SGT': 'SLE',
 }
 
-leaf_operations = backend_symbol_creation_operations | backend_creation_operations | backend_vsa_creation_operations
+leaf_operations = backend_symbol_creation_operations | backend_creation_operations
 leaf_operations_concrete = backend_creation_operations
 leaf_operations_symbolic = backend_symbol_creation_operations
 
@@ -392,7 +388,7 @@ leaf_operations_symbolic = backend_symbol_creation_operations
 # Reversibility
 #
 
-not_invertible = {'Identical', 'union'}
+not_invertible = {'union'}
 reverse_distributable = { 'widen', 'union', 'intersection',
     '__invert__', '__or__', '__ror__', '__and__', '__rand__', '__xor__', '__rxor__',
 }

--- a/claripy/ops.py
+++ b/claripy/ops.py
@@ -28,6 +28,3 @@ from .ast.strings import *
 from . import vsa
 
 VS = ValueSet
-#SI = StridedInterval
-#TSI = TopStridedInterval
-#ESI = EmptyStridedInterval


### PR DESCRIPTION
These five ops are un-implemented throughout claripy, _at least as ops_. This PR is related to the conversation @ltfish, @zardus, and I had about these ops and how they should be removed.