### PR TITLE
Remove long from claripy; it was unified with int before python 3

### DIFF
--- a/claripy/ast/fp.py
+++ b/claripy/ast/fp.py
@@ -126,8 +126,8 @@ fpToFPUnsigned = operations.op('fpToFPUnsigned', (fp.RM, BV, fp.FSort), FP, boun
 fpFP = operations.op('fpFP', (BV, BV, BV), FP, bound=False,
                   calc_length=lambda a, b, c: a.length + b.length + c.length)
 fpToIEEEBV = operations.op('fpToIEEEBV', (FP,), BV, bound=False, calc_length=lambda fp: fp.length)
-fpToSBV = operations.op('fpToSBV', (fp.RM, FP, (int)), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
-fpToUBV = operations.op('fpToUBV', (fp.RM, FP, (int)), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
+fpToSBV = operations.op('fpToSBV', (fp.RM, FP, int), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
+fpToUBV = operations.op('fpToUBV', (fp.RM, FP, int), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
 
 #
 # unbound float point comparisons

--- a/claripy/ast/fp.py
+++ b/claripy/ast/fp.py
@@ -1,5 +1,3 @@
-from past.builtins import long
-
 from .bits import Bits
 from ..ast.base import _make_name
 
@@ -128,8 +126,8 @@ fpToFPUnsigned = operations.op('fpToFPUnsigned', (fp.RM, BV, fp.FSort), FP, boun
 fpFP = operations.op('fpFP', (BV, BV, BV), FP, bound=False,
                   calc_length=lambda a, b, c: a.length + b.length + c.length)
 fpToIEEEBV = operations.op('fpToIEEEBV', (FP,), BV, bound=False, calc_length=lambda fp: fp.length)
-fpToSBV = operations.op('fpToSBV', (fp.RM, FP, (int, long)), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
-fpToUBV = operations.op('fpToUBV', (fp.RM, FP, (int, long)), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
+fpToSBV = operations.op('fpToSBV', (fp.RM, FP, (int)), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
+fpToUBV = operations.op('fpToUBV', (fp.RM, FP, (int)), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
 
 #
 # unbound float point comparisons

--- a/claripy/vsa/strided_interval.py
+++ b/claripy/vsa/strided_interval.py
@@ -338,10 +338,10 @@ class StridedInterval(BackendObject):
         self._upper_bound = upper_bound if upper_bound is not None else (2**bits-1)
 
         if lower_bound is not None and not isinstance(lower_bound, numbers.Number):
-            raise ClaripyVSAError("'lower_bound' must be an int or a long. %s is not supported." % type(lower_bound))
+            raise ClaripyVSAError("'lower_bound' must be an int. %s is not supported." % type(lower_bound))
 
         if upper_bound is not None and not isinstance(upper_bound, numbers.Number):
-            raise ClaripyVSAError("'upper_bound' must be an int or a long. %s is not supported." % type(upper_bound))
+            raise ClaripyVSAError("'upper_bound' must be an int. %s is not supported." % type(upper_bound))
 
         self._reversed = False
 


### PR DESCRIPTION
We no longer need to support python2.