### PR TITLE
__divmod__ op removed

### DIFF
--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -399,8 +399,6 @@ BV.__pow__ = operations.op('__pow__', (BV, BV), BV, extra_check=operations.lengt
 BV.__rpow__ = operations.reversed_op(BV.__pow__)
 BV.__mod__ = operations.op('__mod__', (BV, BV), BV, extra_check=operations.length_same_check, calc_length=operations.basic_length_calc)
 BV.__rmod__ = operations.reversed_op(BV.__mod__)
-BV.__divmod__ = operations.op('__divmod__', (BV, BV), BV, extra_check=operations.length_same_check, calc_length=operations.basic_length_calc)
-BV.__rdivmod__ = operations.reversed_op(BV.__divmod__)
 BV.SDiv = operations.op('SDiv', (BV, BV), BV, extra_check=operations.length_same_check, bound=False, calc_length=operations.basic_length_calc)
 BV.SMod = operations.op('SMod', (BV, BV), BV, extra_check=operations.length_same_check, bound=False, calc_length=operations.basic_length_calc)
 

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -222,7 +222,6 @@ expression_arithmetic_operations = {
     '__sub__', '__rsub__',
     '__pow__', '__rpow__',
     '__mod__', '__rmod__',
-    '__divmod__', '__rdivmod__',
     'SDiv', 'SMod',
     '__neg__',
     '__pos__',
@@ -332,7 +331,6 @@ opposites = {
     '__sub__': '__rsub__', '__rsub__': '__sub__',
     '__pow__': '__rpow__', '__rpow__': '__pow__',
     '__mod__': '__rmod__', '__rmod__': '__mod__',
-    '__divmod__': '__rdivmod__', '__rdivmod__': '__divmod__',
 
     '__eq__': '__eq__',
     '__ne__': '__ne__',
@@ -358,7 +356,6 @@ reversed_ops = {
     '__radd__': '__add__',
     '__rand__': '__and__',
     '__rdiv__': '__div__',
-    '__rdivmod__': '__divmod__',
     '__rfloordiv__': '__floordiv__',
     '__rlshift__': '__lshift__',
     '__rmod__': '__mod__',
@@ -406,7 +403,6 @@ infix = {
     '__truediv__': '/', # the raw / operator should use integral semantics on bitvectors
     '__pow__': '**',
     '__mod__': '%',
-#    '__divmod__': "don't think this is used either",
 
     '__eq__': '==',
     '__ne__': '!=',
@@ -459,7 +455,6 @@ op_precedence = {  # based on https://en.cppreference.com/w/c/language/operator_
     '__floordiv__': 3,
     '__truediv__': 3, # the raw / operator should use integral semantics on bitvectors
     '__mod__': 3,
-    #'__divmod__': "don't think this is used either",
     'SDiv': 3,
     'SMod': 3,
 


### PR DESCRIPTION
The divmod op doesn't seem to have any backend support and seems unused. It also seems like shoving a python op into the AST rather than making a python wrapper (for example it would be like making `__radd__` a legitimate op rather than a python wrapper for the add `__add__` op. This was related to my conversation with @ltfish and @zardus 