### PR TITLE
Rm unit str

### DIFF
--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -154,7 +154,6 @@ StrIndexOf = operations.op("StrIndexOf", (String, String, BV, int), BV, calc_len
 StrToInt = operations.op("StrToInt", (String, int), BV, calc_length=operations.strtoint_bv_size_calc, bound=False)
 IntToStr = operations.op("IntToStr", (BV,), String, calc_length=operations.int_to_str_length_calc, bound=False)
 StrIsDigit = operations.op("StrIsDigit", (String,), Bool, bound=False)
-UnitStr = operations.op("UnitStr", (BV,), String, bound=False) # convert BV to single-char string
 
 # Equality / inequality check
 String.__eq__ = operations.op('__eq__', (String, String), Bool)
@@ -174,4 +173,3 @@ String.StrIndexOf = staticmethod(StrIndexOf)
 String.StrToInt = staticmethod(StrToInt)
 String.StrIsDigit = staticmethod(StrIsDigit)
 String.IntToStr = staticmethod(IntToStr)
-String.UnitStr = staticmethod(UnitStr)

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1362,13 +1362,13 @@ class BackendZ3(Backend):
 
     @staticmethod
     @condom
-    def _op_raw_IntToStr(input_bvv):
-        return z3.IntToStr(z3.BV2Int(input_bvv))
+    def _op_raw_IntToStr(input_bv):
+        return z3.IntToStr(z3.BV2Int(input_bv))
 
     @staticmethod
     @condom
-    def _op_raw_UnitStr(input_bvv):
-        return z3.Unit(input_bvv)
+    def _op_raw_UnitStr(input_bv):
+        return z3.Unit(input_bv)
 #
 # this is for the actual->abstract conversion above
 #

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1364,11 +1364,6 @@ class BackendZ3(Backend):
     @condom
     def _op_raw_IntToStr(input_bv):
         return z3.IntToStr(z3.BV2Int(input_bv))
-
-    @staticmethod
-    @condom
-    def _op_raw_UnitStr(input_bv):
-        return z3.Unit(input_bv)
 #
 # this is for the actual->abstract conversion above
 #


### PR DESCRIPTION
UnitStr was unused as far as I know and also did not do was intended; it returned a sequence not a string so it probably wasn't use-able in the first place in ASTs.