### PR TITLE
rm StrExtract

### DIFF
--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -42,7 +42,7 @@ class String(Bits):
             # Because we are indexing from the end, what was high becomes low and vice-versa
             high_str_idx = self.string_length - 1 - low
             low_str_idx = self.string_length - 1 - high
-            return StrExtract(low_str_idx, high_str_idx + 1 - low_str_idx, self)
+            return StrSubstr(high_str_idx + 1 - low_str_idx, 2*low_str_idx - high_str_idx, self)
         else:
             raise ValueError("Only slices allowed for string extraction")
 
@@ -62,7 +62,7 @@ class String(Bits):
     @staticmethod
     def _from_str(like, value):
         return StringV(value)
-    
+
     def strReplace(self, str_to_replace, replacement):
         """
         Replace the first occurence of str_to_replace with replacement
@@ -140,9 +140,6 @@ def StringV(value, length=None, **kwargs):
 StrConcat = operations.op('StrConcat', String, String, calc_length=operations.str_concat_length_calc, bound=False)
 StrSubstr = operations.op('StrSubstr', (BV, BV, String),
                         String, calc_length=operations.substr_length_calc, bound=False)
-StrExtract = operations.op('StrExtract', (int, int, String),
-                              String, extra_check=operations.str_extract_check,
-                              calc_length=operations.str_extract_length_calc, bound=False)
 StrLen = operations.op('StrLen', (String, int), BV, calc_length=operations.strlen_bv_size_calc, bound=False)
 StrReplace = operations.op('StrReplace', (String, String, String), String,
                         extra_check=operations.str_replace_check,
@@ -163,7 +160,6 @@ String.__ne__ = operations.op('__ne__', (String, String), Bool)
 # String manipulation
 String.__add__ = StrConcat
 String.StrSubstr = staticmethod(StrSubstr)
-String.StrExtract = staticmethod(StrExtract)
 String.StrConcat = staticmethod(StrConcat)
 String.StrLen = staticmethod(StrLen)
 String.StrReplace = staticmethod(StrReplace)

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -47,7 +47,7 @@ class String(Bits):
             bits_low = rng.start if rng.start is not None else 0
             bits_high = rng.stop if rng.stop is not None else 8*(self.string_length - 1)
             if bits_high % 8 != 0 or (bits_low+1) % 8 != 0:
-                raise ValueError('Bit indicies must correspond to byte indicies! I.e. be divisible by 8.')
+                raise ValueError('Bit indicies must not internally divide bytes!')
             # high / low form a reverse-indexed byte index
             high = bits_high // 8
             low = bits_low // 8

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -40,7 +40,7 @@ class String(Bits):
         Examples:
             self[7:0]  -- returns the last byte of self
             self[15:0] -- returns the last two bytes of self
-            self[8:0]  -- Error! [8:0] is 9 bytes, it asks for individual bits of the second to last byte!
+            self[8:0]  -- Error! [8:0] is 9 bits, it asks for individual bits of the second to last byte!
             self[8:1]  -- Error! [8:1] asks for 1 bit from the second to last byte and 7 from the last byte!
         '''
         if type(rng) is slice:

--- a/claripy/backends/backend_smtlib.py
+++ b/claripy/backends/backend_smtlib.py
@@ -91,7 +91,6 @@ class BackendSMTLibBase(Backend):
         # ------------------- STRINGS OPERATIONS -------------------
         self._op_raw['StrConcat'] = self._op_raw_str_concat
         self._op_raw['StrSubstr'] = self._op_raw_str_substr
-        self._op_raw['StrExtract'] = self._op_raw_str_extract
         self._op_raw['StrLen'] = self._op_raw_str_strlen
         self._op_raw['StrReplace'] = self._op_raw_str_replace
         self._op_raw["StrContains"] = self._op_raw_str_contains
@@ -264,10 +263,6 @@ class BackendSMTLibBase(Backend):
         # start_idx_operand = BVToNatural(start_idx) if start_idx.get_type().is_bv_type() else start_idx
         # count_operand = BVToNatural(count) if count.get_type().is_bv_type() else count
         return StrSubstr(symb, start_idx_operand, count_operand)
-
-    def _op_raw_str_extract(self, *args):
-        start_idx, count, symb = args
-        return StrSubstr(symb, Int(start_idx), Int(count))
 
     def _op_raw_str_strlen(self, *args):
         return StrLength(args[0])

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1319,11 +1319,6 @@ class BackendZ3(Backend):
 
     @staticmethod
     @condom
-    def _op_raw_StrExtract(high, low, str_val):
-        return z3.SubString(str_val, low, high + 1 - low)
-
-    @staticmethod
-    @condom
     def _op_raw_StrLen(input_string, bitlength):
         return z3.Int2BV(z3.Length(input_string), bitlength)
 

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -154,19 +154,6 @@ def extract_length_calc(high, low, _):
 def str_basic_length_calc(str_1):
     return str_1.string_length
 
-def str_extract_check(start_idx, count, str_val):
-    if start_idx < 0:
-        return False, "StrExtract start_idx must be nonnegative"
-    elif count <= 0:
-        return False, "StrExtract count must be positive"
-    elif start_idx + count > str_val.string_length:
-        return False, "count must not exceed the length of the string."
-    else:
-        return True, ""
-
-def str_extract_length_calc(start_idx, count, str_val): # pylint: disable=unused-argument
-    return count
-
 def int_to_str_length_calc(int_val): # pylint: disable=unused-argument
     return ast.String.MAX_LENGTH
 

--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -32,7 +32,6 @@ class SimplificationManager:
             'SignExt': self.signext_simplifier,
             'fpToIEEEBV': self.fptobv_simplifier,
             'fpToFP': self.fptofp_simplifier,
-            'StrExtract': self.str_extract_simplifier,
             'StrReverse': self.str_reverse_simplifier,
         }
 
@@ -851,18 +850,6 @@ class SimplificationManager:
         masked_a = (a_00 & m)
         expr = (masked_a << lshift_) | (masked_a >> rshift_)
         return expr
-
-    @staticmethod
-    def str_extract_simplifier(start_idx, count, val):
-        if start_idx == 0 and count == val.string_length:
-            return val
-        # if we are dealing with a chain of extractions on the same string we can
-        # simplify the chain in one single StrExtract
-        if val.op == 'StrExtract':
-            v_start_idx, _, v_str = val.args
-            new_start = v_start_idx + start_idx
-            new_count = count
-            return v_str.StrExtract(new_start, new_count, v_str)
 
     @staticmethod
     def str_reverse_simplifier(arg):

--- a/claripy/strings.py
+++ b/claripy/strings.py
@@ -37,10 +37,6 @@ def StrSubstr(start_idx, count, initial_string):
     return StringV(new_value)
 
 
-def StrExtract(high, low, str_val):
-    return StrSubstr(low, high + 1 - low, str_val)
-
-
 def StrReplace(initial_string, pattern_to_be_replaced, replacement_pattern):
     """
     Return string where the first occurrence of `pattern_to_be_replaced` is replaced with

--- a/tests/test_backend_smt.py
+++ b/tests/test_backend_smt.py
@@ -419,21 +419,6 @@ class TestSMTLibBackend(unittest.TestCase):
         script = solver.get_smtlib_script_satisfiability()
         self.assertEqual(correct_script, script)
 
-    def test_str_extract(self):
-        correct_script = '''(set-logic ALL)
-(declare-fun STRING_symb_str_extract () String)
-(assert (let ((.def_0 (= ( str.substr STRING_symb_str_extract 5 1) "abc"))) .def_0))
-(check-sat)
-'''
-        str_symb = claripy.StringS("symb_str_extract", 12, explicit_name=True)
-        res = claripy.StrExtract(0, 1, claripy.StrExtract(1, 2, claripy.StrExtract(4, 8, str_symb)))
-        solver = self.get_solver()
-        solver.add(res == claripy.StringV("abc"))
-        script = solver.get_smtlib_script_satisfiability()
-        # with open("dump_strextract.smt2", "w") as dump_f:
-        #     dump_f.write(script)
-        self.assertEqual(correct_script, script)
-
     def test_is_digit(self):
         correct_script = '''(set-logic ALL)
 (declare-fun STRING_symb_str_is_digit () String)

--- a/tests/test_backend_smt.py
+++ b/tests/test_backend_smt.py
@@ -1,7 +1,7 @@
 import unittest
 import claripy
 
-from claripy import frontend_mixins, frontends, backend_manager, backends
+from claripy import frontend_mixins, backend_manager
 from claripy.backends.backend_smtlib import BackendSMTLibBase
 from claripy.frontends.constrained_frontend import ConstrainedFrontend
 from claripy.ast.strings import String
@@ -20,10 +20,10 @@ class TestSMTLibBackend(unittest.TestCase):
             frontend_mixins.EagerResolutionMixin,
             frontend_mixins.SMTLibScriptDumperMixin,
             ConstrainedFrontend
-        ):
+        ):  # pylint:disable=abstract-method
             def __init__(self, *args, **kwargs):
                 self._solver_backend = backend_manager.backends.smt
-                super(SolverSMT, self).__init__(*args, **kwargs)
+                super().__init__(*args, **kwargs)
 
         return SolverSMT()
 


### PR DESCRIPTION
StrExtract is not used much as far as I can tell; is buggy / incorrect, and depends on z3 code that is buggy / has incorrect documentation. Furthermore, it is just an alias of SubStr

I replaced usages of StrExtract with their equivalent SubStr calls; so this should not affect runs much; however, since StrExtract was buggy, the call to SubStr (since I converted the arguments) likely is too.