### PR TITLE
Fix wrong enum type to prevent future bugs.

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -674,7 +674,7 @@ class BackendZ3(Backend):
         # see https://stackoverflow.com/a/58829514/3154996
         if z3.Z3_get_decl_num_parameters(ctx, decl) != 1:
             raise BackendError("Weird Z3 model")
-        if z3.Z3_get_decl_parameter_kind(ctx, decl, 0) != z3.Z3_PK_SYMBOL:
+        if z3.Z3_get_decl_parameter_kind(ctx, decl, 0) != z3.Z3_PARAMETER_SYMBOL:
             raise BackendError("Weird Z3 model")
         symb = z3.Z3_get_decl_symbol_parameter(ctx, decl, 0)
         if z3.Z3_get_symbol_kind(ctx, symb) != z3.Z3_STRING_SYMBOL:


### PR DESCRIPTION
Before we used the wrong enum and were lucky the two numbers happened to match. Switch from `Z3_param_kind` enum to` Z3_parameter_kind` enum