### PR TITLE
Fallback to hashlib if _md5 is unavailable

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -3,7 +3,6 @@ import logging
 import os
 import struct
 import weakref
-import _md5  # Python's build-in MD5 is about 2x faster than hashlib.md5 on short bytestrings
 from collections import OrderedDict, deque
 from typing import Optional
 
@@ -11,6 +10,12 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
+
+try:
+    # Python's build-in MD5 is about 2x faster than hashlib.md5 on short bytestrings
+    import _md5 as md5
+except ImportError:
+    import hashlib as md5
 
 l = logging.getLogger("claripy.ast")
 
@@ -267,7 +272,7 @@ class Base:
         # Why do we use md5 when it's broken? Because speed is more important
         # than cryptographic integrity here. Then again, look at all those
         # allocations we're doing here... fast python is painful.
-        hd = _md5.md5(to_hash).digest()
+        hd = md5.md5(to_hash).digest()
         return md5_unpacker.unpack(hd)[0] # 64 bits
 
     @staticmethod


### PR DESCRIPTION
Some Python distributions do not include the _md5 module.