### PR TITLE
Distinguish between +0.0 and -0.0 in FPV

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -212,7 +212,12 @@ class Base:
         if hash is not None:
             h = hash
         elif op in {'BVS', 'BVV', 'BoolS', 'BoolV', 'FPS', 'FPV'} and not annotations:
-            h = (op, kwargs.get('length', None), a_args)
+            if op == "FPV" and a_args[0] == 0.0 and math.copysign(1, a_args[0]) < 0:
+                # Python does not distinguish between +0.0 and -0.0 so we add sign to tuple to distinguish
+                h = (op, kwargs.get('length', None), ("-",) + a_args)
+            else:
+                h = (op, kwargs.get('length', None), a_args)
+
             cache = cls._leaf_cache
         else:
             h = Base._calc_hash(op, a_args, kwargs) if hash is None else hash

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -20,6 +20,20 @@ def test_nan():
     res = s3.eval(a.raw_to_bv(), 1)[0]
     assert res & 0xff800000 == 0x7f800000 and res & 0x007fffff != 0
 
+def test_negative_zero():
+    """
+    Python does not distinguish between +0.0 and -0.0 and thus, claripy returns same AST for both. However, they have
+    different bit representations and hence are different.
+    """
+
+    zd = claripy.FPV(0.0, claripy.FSORT_DOUBLE)
+    nzd = claripy.FPV(-0.0, claripy.FSORT_DOUBLE)
+    zf = claripy.FPV(0.0, claripy.FSORT_FLOAT)
+    nzf = claripy.FPV(-0.0, claripy.FSORT_FLOAT)
+    s = claripy.Solver()
+    assert s.eval(nzd.to_bv(), 1)[0] == 0x8000000000000000
+    assert s.eval(nzf.to_bv(), 1)[0] == 0x80000000
+
 def test_fp_ops():
     a = claripy.FPV(1.5, claripy.FSORT_DOUBLE)
     b = claripy.fpToUBV(claripy.fp.RM_NearestTiesEven, a, 32)
@@ -30,3 +44,4 @@ def test_fp_ops():
 if __name__ == '__main__':
     test_fp_ops()
     test_nan()
+    test_negative_zero()


### PR DESCRIPTION
Python does not distinguish between +0.0 and -0.0 and as a result, claripy returns the cached object for +0.0(if it exists) for -0.0 and vice versa. This PR fixes this by using different hash keys for +0.0 and -0.0 when caching the FPV objects.