### PR TITLE
Correctly create single-precision floating-point values

### DIFF
--- a/claripy/ast/fp.py
+++ b/claripy/ast/fp.py
@@ -1,5 +1,8 @@
+import struct
+
 from .bits import Bits
 from ..ast.base import _make_name
+from ..fp import FSORT_FLOAT
 
 class FP(Bits):
     """
@@ -101,6 +104,11 @@ def FPV(value, sort):
 
     if type(sort) is not fp.FSort:
         raise TypeError("Must instanciate FPV with a FSort")
+
+    if sort == FSORT_FLOAT:
+        # By default, Python treats all floating-point numbers as double-precision. However, a single-precision float is
+        # being created here. Hence, we need to convert value to single-precision.
+        value = struct.unpack("f", struct.pack("f", value))[0]
 
     return FP('FPV', (value, sort), length=sort.length)
 

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -41,7 +41,16 @@ def test_fp_ops():
     s = claripy.Solver()
     assert s.eval(b, 1)[0] == 2
 
+def test_fp_precision_loss():
+    dd = claripy.FPV(101817237862.0, claripy.FSORT_DOUBLE)
+    s = claripy.Solver()
+    edd = s.eval(dd.to_bv(), 1)[0]
+    edd2 = s.eval(dd.to_fp(claripy.FSORT_FLOAT).to_fp(claripy.FSORT_DOUBLE).to_bv(), 1)[0]
+    assert edd != edd2
+    assert edd2 == 0x4237b4c7c0000000
+
 if __name__ == '__main__':
     test_fp_ops()
     test_nan()
     test_negative_zero()
+    test_fp_precision_loss()


### PR DESCRIPTION
By default, Python treats floating point numbers as double-precision floats. This becomes a problem when creating concrete single-precision floating point values since value stored would still be double-precision. To work around this, we pack the number to bytes, unpack those bytes and create an FPV from the resulting floating point value.