### PR TITLE
Ensure relocatable_annotations is concretized when assigned.

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -197,10 +197,10 @@ class Base:
                 tuple(a for a in annotations if not a.eliminatable and not a.relocatable)
             ))
 
-            relocatable_annotations = OrderedDict((e, True) for e in tuple(itertools.chain(
+            relocatable_annotations = tuple(OrderedDict((e, True) for e in tuple(itertools.chain(
                 itertools.chain.from_iterable(a._relocatable_annotations for a in ast_args) if not skip_child_annotations else tuple(),
                 tuple(a for a in annotations if not a.eliminatable and a.relocatable)
-            ))).keys()
+            ))).keys())
 
             annotations = tuple(itertools.chain(
                 itertools.chain.from_iterable(a._relocatable_annotations for a in ast_args) if not skip_child_annotations else tuple(),


### PR DESCRIPTION
Otherwise it will evaluate `itertools.chain()` using the context when `_relocatable_annotations` is accessed, leading to weird issues like this:

```
Traceback (most recent call last):
  File "/home/clasm/projects/angr-squad/operation-mango/package/argument_resolver/utils.py", line 55, in _get_strings_from_concrete_memory_area
    values = state.memory_definitions.load(string_pointer+size, size=1)
  File "/home/clasm/projects/angr-squad/angr/angr/storage/memory_mixins/size_resolution_mixin.py", line 28, in load
    return super().load(addr, size=out_size, **kwargs)
  File "/home/clasm/projects/angr-squad/angr/angr/storage/memory_mixins/paged_memory/paged_memory_mixin.py", line 144, in load
    out = self.PAGE_TYPE._compose_objects(vals, size, endness, memory=self, **kwargs)
  File "/home/clasm/projects/angr-squad/angr/angr/storage/memory_mixins/paged_memory/pages/cooperation.py", line 137, in _compose_objects
    chopped = o.bytes_at(
  File "/home/clasm/projects/angr-squad/angr/angr/storage/memory_object.py", line 80, in bytes_at
    thing = bv_slice(self.object, offset, length, self.endness == 'Iend_LE', self._byte_width)
  File "/home/clasm/projects/angr-squad/angr/angr/storage/memory_object.py", line 174, in bv_slice
    return value[bitstart - 1:bitstart - size * bw]
  File "/home/clasm/projects/angr-squad/claripy/claripy/ast/bv.py", line 71, in __getitem__
    return Extract(left, right, self)
  File "/home/clasm/projects/angr-squad/claripy/claripy/operations.py", line 68, in _op
    return return_type(name, fixed_args, **kwargs)
  File "/home/clasm/projects/angr-squad/claripy/claripy/ast/base.py", line 161, in __new__
    r = operations._handle_annotations(eb._abstract(eb.call(op, args)), args)
  File "/home/clasm/projects/angr-squad/claripy/claripy/operations.py", line 84, in _handle_annotations
    for oa in aa._relocatable_annotations:
KeyError: <angr.knowledge_plugins.key_definitions.live_definitions.DefinitionAnnotation object at 0x7f354ba5fb40>
```