### PR TITLE
Z3: clone the solver instead of adding constraints to a fresh instance

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -701,6 +701,12 @@ class BackendZ3(Backend):
                 s.set('timeout', timeout)
         return s
 
+    def clone_solver(self, s):
+        # This clones the solver.
+        # See https://github.com/Z3Prover/z3/issues/556
+        clone = s.translate(self._context)
+        return clone
+
     def _add(self, s, c, track=False):
         if track:
             already_tracked = set(str(impl.children()[0]) for impl in s.assertions())

--- a/claripy/frontends/full_frontend.py
+++ b/claripy/frontends/full_frontend.py
@@ -63,7 +63,11 @@ class FullFrontend(ConstrainedFrontend):
         if len(self._to_add) > 0:
             self._add_constraints()
 
-        return self._tls.solver
+        solver = self._tls.solver
+        if self._solver_backend.reuse_z3_solver:
+            # we must re-add all constraints
+            self._add_constraints()
+        return solver
 
     def _add_constraints(self):
         self._solver_backend.add(self._tls.solver, self.constraints, track=self._track)

--- a/claripy/frontends/full_frontend.py
+++ b/claripy/frontends/full_frontend.py
@@ -54,15 +54,15 @@ class FullFrontend(ConstrainedFrontend):
             self._tls.solver = self._solver_backend.solver(timeout=self.timeout)
             self._add_constraints()
         elif self._finalized and len(self._to_add) > 0:
-            if self._solver_backend.reuse_z3_solver:
+            if not hasattr(self._solver_backend, 'clone_solver') or self._solver_backend.reuse_z3_solver:
                 self._tls.solver = self._solver_backend.solver(timeout=self.timeout)
-            else: 
-                self._tls.solver = self._solver_backend.clone_solver(self._tls.solver)            
+            else:
+                self._tls.solver = self._solver_backend.clone_solver(self._tls.solver)
             self._add_constraints()
-            
+
         if len(self._to_add) > 0:
             self._add_constraints()
-            
+
         return self._tls.solver
 
     def _add_constraints(self):


### PR DESCRIPTION
This results in increased incrementalism and thus speeds up further queries (See https://github.com/Z3Prover/z3/issues/556). Leads to 10-25% reduction in execution time in my private benchmarks.