### PR TITLE
Avoid single-argument nodes in simplifications

### DIFF
--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -473,6 +473,9 @@ class SimplificationManager:
         if filter_func: new_args = filter_func(new_args)
         if not new_args and 'initial_value' in kwargs:
             return kwargs['initial_value']
+        # if a single arg is left, don't create an op for it
+        if len(new_args) == 1:
+            return new_args[0]
         return next(a for a in args if isinstance(a, ast.Base)).make_like(op_name, new_args,
                                                                           variables=variables,
                                                                           simplify=False)


### PR DESCRIPTION
Having nodes with a single argument, e.g. "add(42)" is rather annoying as they look the same but don't behave the same (e.g. for `structurally_match`) as their lone arg.