### PR TITLE
Clear caches after simplifying constraints in Z3 backend

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -974,7 +974,7 @@ class BackendZ3(Backend):
         #l.debug("... after:\n%s", z3_expr_to_smt2(s))
 
         o = self._abstract(s)
-        self.downsize()
+        self._ast_cache.clear()
         o._simplified = Base.FULL_SIMPLIFY
 
         if self._enable_simplification_cache:

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -974,6 +974,7 @@ class BackendZ3(Backend):
         #l.debug("... after:\n%s", z3_expr_to_smt2(s))
 
         o = self._abstract(s)
+        self.downsize()
         o._simplified = Base.FULL_SIMPLIFY
 
         if self._enable_simplification_cache:


### PR DESCRIPTION
During simplification, many Z3 ASTs(and other data) are cached to speed up the process. However, these ASTs references are never freed and thus Z3 treats them as memory leaks. This PR fixes this by clearing the caches after each simplification performed by the Z3 backend.