### PR TITLE
Allow usages of BV to be typechecked

### DIFF
--- a/claripy/ast/__init__.py
+++ b/claripy/ast/__init__.py
@@ -1,15 +1,30 @@
 #pylint:disable=redefined-outer-name
-Bits = lambda *args, **kwargs: None
-BV = lambda *args, **kwargs: None
-VS = lambda *args, **kwargs: None
-FP = lambda *args, **kwargs: None
-Bool = lambda *args, **kwargs: None
-Int = lambda *args, **kwargs: None
-Base = lambda *args, **kwargs: None
-true = lambda *args, **kwargs: None
-false = lambda *args, **kwargs: None
-String = lambda *args, **kwargs: None
-all_operations = None
+from typing import TYPE_CHECKING
+# Mypy is severely confused by this delayed import trickery, but works if we just pretend that the import
+# happens here already
+if TYPE_CHECKING:
+    from .bits import Bits
+    from .bv import BV
+    from .vs import VS
+    from .fp import FP
+    from .bool import Bool, true, false
+    from .int import Int
+    from .base import Base
+    from .strings import String
+    from .. import ops as all_operations
+else:
+    Bits = lambda *args, **kwargs: None
+    BV = lambda *args, **kwargs: None
+    VS = lambda *args, **kwargs: None
+    FP = lambda *args, **kwargs: None
+    Bool = lambda *args, **kwargs: None
+    Int = lambda *args, **kwargs: None
+    Base = lambda *args, **kwargs: None
+    true = lambda *args, **kwargs: None
+    false = lambda *args, **kwargs: None
+    String = lambda *args, **kwargs: None
+    all_operations = None
+
 
 def _import():
     global Bits, BV, VS, FP, Bool, Int, Base, String, true, false, all_operations

--- a/claripy/py.typed
+++ b/claripy/py.typed
@@ -1,0 +1,1 @@
+PARTIAL

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,7 @@ setup(
     ],
     description='An abstraction layer for constraint solvers',
     url='https://github.com/angr/claripy',
+    package_data={
+        'claripy': ["py.typed"]
+    },
 )


### PR DESCRIPTION
The delayed import construct completely confuses mypy, so this hides it
from the type checker. To allow mypy to recognize that claripy has basic
typing support the `py.typed` file is also added to the `setup.py`