### PR TITLE
Also handle Concat in zeroext_comparing_against_simplifier

### DIFF
--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -982,9 +982,15 @@ class SimplificationManager:
         If the high bits of b are all zeros (in case of __eq__) or have at least one ones (in case of __ne__), ZeroExt
         can be eliminated.
         """
-        if op in {operator.__eq__, operator.__ne__} and a.op == "ZeroExt" and b.op == "BVV":
+        if op in {operator.__eq__, operator.__ne__} and b.op == "BVV":
             # check if the high bits of b are zeros
-            a_zeroext_bits = a.args[0]
+            if a.op == "ZeroExt":
+                a_zeroext_bits = a.args[0]
+            elif a.op == "Concat" and len(a.args) == 2 and (a.args[0] == 0).is_true():
+                a_zeroext_bits = a.args[0].size()
+            else:
+                return None
+
             b_highbits = b[b.size() - 1 : b.size() - a_zeroext_bits]
             if (b_highbits == 0).is_true():
                 # we can get rid of ZeroExt


### PR DESCRIPTION
Adds handling to `zeroext_comparing_against_simplifier` when `Concat` is used like a `ZeroExt`.

Helps to reduce:
```
[<Bool (0 .. (if reg_rdi_19_64{UNINITIALIZED} == 0x0 then 1 else 0)) != 0>]
[<Bool (0 .. (if reg_rdi_19_64{UNINITIALIZED} == 0x0 then 1 else 0)) == 0>]
```

to:
```
[<Bool reg_rdi_19_64{UNINITIALIZED} == 0x0>]
[<Bool reg_rdi_19_64{UNINITIALIZED} != 0x0>]
```

This `ZeroExt+Concat` handling pattern is used in other simplifiers; maybe we should just add a simplifier to convert `Concat(BVV(0,n) .. x) => ZeroExt(n, x)` to simplify some of these handlers, but it's left for future work.
