### PR TITLE
Use a binary shift instead of exponentiation in `claripy.Extract`

### DIFF
--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -288,7 +288,7 @@ def SignExt(num, o):
     return BVV(o.signed, o.bits + num)
 
 def Extract(f, t, o):
-    return BVV((o.value >> t) & (2**(f+1) - 1), f-t+1)
+    return BVV((o.value >> t) & ((1 << (f + 1)) - 1), f + 1 - t)
 
 def Concat(*args):
     total_bits = 0


### PR DESCRIPTION
Closes #267 