### PR TITLE
Make the mask `claripy.Extract` uses smaller to avoid double truncate

### DIFF
--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -288,7 +288,7 @@ def SignExt(num, o):
     return BVV(o.signed, o.bits + num)
 
 def Extract(f, t, o):
-    return BVV((o.value >> t) & ((1 << (f + 1)) - 1), f + 1 - t)
+    return BVV((o.value >> t) & ((1 << (f + 2 - t)) - 1), f + 1 - t)
 
 def Concat(*args):
     total_bits = 0


### PR DESCRIPTION
`claripy.Extract` currently uses a mask of `f` 1-bits, and the resulting value is put in a `BVV` with only `f - t + 1` bits. The result is the same if only `f - t + 1` bits were used in the initial mask, so this PR makes the mask just as big as it should be to avoid another truncation when the `BVV` is constructed. This improves the performance if both `f` and `t` are large.