### PR TITLE
remove dependency future

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ long_description_content_type = text/markdown
 [options]
 install_requires =
     z3-solver >= 4.8.5.0
-    future
     cachetools
     decorator
     pysmt >= 0.9.1.dev119


### PR DESCRIPTION
As angr requires a minimal Python version 3.8 and there is no use of __future__ and builtins, I think it's safe to remove future from dependencies.