### PR TITLE
Annotate ASTs faster.

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -462,6 +462,7 @@ class Base:
         if simplified is None \
                 and len(kwargs) == 3 \
                 and 'annotations' in kwargs \
+                and kwargs['annotations'] \
                 and 'skip_child_annotations' in kwargs \
                 and kwargs['skip_child_annotations'] is True \
                 and 'length' in kwargs:

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -467,8 +467,10 @@ class Base:
                 and 'length' in kwargs:
             # fast path
             annotations = tuple(kwargs['annotations'])
-            uneliminatable_annotations = frozenset(anno for anno in annotations if not anno.eliminatable)
-            relocatable_annotations = tuple(anno for anno in annotations if anno.relocatable)
+            uneliminatable_annotations = frozenset(anno for anno in annotations
+                                                   if not anno.eliminatable and not anno.relocatable)
+            relocatable_annotations = tuple(anno for anno in annotations
+                                            if not anno.eliminatable and anno.relocatable)
 
             return type(self).__init_with_annotations__(op, args,
                                                         uneliminatable_annotations=uneliminatable_annotations,

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -547,7 +547,7 @@ class Base:
             return self._apply_to_annotations(lambda alist: alist + args)
         else:
             return self._apply_to_annotations(
-                lambda alist: [ arg for arg in alist + args if arg not in remove_annotations ]
+                lambda alist: tuple(arg for arg in alist if arg not in remove_annotations) + args
             )
 
     def insert_annotation(self, a):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -195,3 +195,4 @@ if __name__ == '__main__':
     test_ast_hash_should_consider_relocatable_annotations()
     test_remove_relocatable_annotations()
     test_duplicated_annotations_from_makelike()
+    test_simplification()


### PR DESCRIPTION
This PR makes several improvements:

- Add a fast path in `make_like()` for adding or changing annotations of an existing AST.
- Avoid repeated lookups of `itertools.chain` and `itertools.chain.from_iterable`.
- Allow removing annotations when `annotate()` is called, which avoids creating intermediate annotated ASTs when replacing existing annotations on an AST.