### PR TITLE
pin to z3 == 4.10.2.0 since 4.11 seems to have introduced serious performance regressions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ long_description_content_type = text/markdown
 
 [options]
 install_requires =
-    z3-solver >= 4.8.5.0
+    z3-solver == 4.10.2.0
     cachetools
     decorator
     pysmt >= 0.9.1.dev119


### PR DESCRIPTION
I think this is the cause of CI suddenly falling over as noticed in https://github.com/angr/cle/pull/341