### PR TITLE
Change Bits and String not to edit `ast.length`

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -110,7 +110,7 @@ class Base:
         :param args:                The arguments to the AST operation (i.e., the objects to add)
         :param variables:           The symbolic variables present in the AST (default: empty set)
         :param symbolic:            A flag saying whether or not the AST is symbolic (default: False)
-        :param length:              An integer specifying the length of this AST (default: None)
+        :param length:              An integer specifying the bit length of this AST (default: None)
         :param simplified:          A measure of how simplified this AST is. 0 means unsimplified,
                                         1 means fast-simplified (basically, just undoing the Reverse
                                         op), and 2 means simplified through z3.

--- a/claripy/ast/bits.py
+++ b/claripy/ast/bits.py
@@ -6,20 +6,15 @@ class Bits(Base):
 
     :ivar length:       The length of this value in bits.
     """
-    __slots__ = ['length']
-
-    def __init__(self, *args, **kwargs):
-        length = kwargs.pop('length', None)
-        if length is None:
-            raise ClaripyOperationError("length of Bits must not be None")
-
-        self.length = length
 
     def make_like(self, op, args, **kwargs):
         if 'length' not in kwargs: kwargs['length'] = self.length
         return Base.make_like(self, op, args, **kwargs)
 
     def size(self):
+        """
+        :returns: The bit length of this AST
+        """
         return self.length
 
     def _type_name(self):

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -1,12 +1,11 @@
+from typing import Optional
+
 from .bits import Bits
 from ..ast.base import _make_name
 
 from .. import operations
 from .bool import Bool
 from .bv import BV, BVS, BVV
-
-from typing import Optional
-import math
 
 
 class String(Bits):

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -5,6 +5,7 @@ from .. import operations
 from .bool import Bool
 from .bv import BV, BVS, BVV
 
+from typing import Optional
 import math
 
 
@@ -26,11 +27,12 @@ class String(Bits):
     GENERATED_BVS_IDENTIFIER = 'BVS_'
     MAX_LENGTH = 10000
 
-    def __init__(self, *args, **kwargs):
-        str_len = kwargs['length']
-        kwargs['length'] *= 8
-        super().__init__(*args, **kwargs)
-        self.string_length = str_len
+    def __init__(self, *args, length: int, **kwargs):
+        """
+        :param length: The string byte length
+        """
+        super().__init__(*args, length=length, **kwargs)
+        self.string_length: int = length
 
     def __getitem__(self, rng):
         '''
@@ -133,16 +135,17 @@ def StringS(name, size, uninitialized=False, explicit_name=False, **kwargs):
     :returns:                    The String object representing the symbolic string
     """
     n = _make_name(String.STRING_TYPE_IDENTIFIER + name, size, False if explicit_name is None else explicit_name)
-    result = String("StringS", (n, uninitialized), length=size, symbolic=True, eager_backends=None, uninitialized=uninitialized, variables={n}, **kwargs)
+    result = String("StringS", (n, uninitialized), length=8*size, symbolic=True, eager_backends=None, uninitialized=uninitialized, variables={n}, **kwargs)
     return result
 
-def StringV(value, length=None, **kwargs):
+def StringV(value, length: Optional[int]=None, **kwargs):
     """
     Create a new Concrete string (analogous to z3.StringVal())
 
-    :param value: The constant value of the concrete string
+    :param value:  The constant value of the concrete string
+    :param length: The byte length of the string
 
-    :returns:                    The String object representing the concrete string
+    :returns:      The String object representing the concrete string
     """
 
     if length is None:
@@ -151,7 +154,7 @@ def StringV(value, length=None, **kwargs):
     if length < len(value):
         raise ValueError("Can't make a concrete string value longer than the specified length!")
 
-    result = String("StringV", (value, len(value)), length=length, **kwargs)
+    result = String("StringV", (value, length), length=8*length, **kwargs)
     return result
 
 StrConcat = operations.op('StrConcat', String, String, calc_length=operations.str_concat_length_calc, bound=False)

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -155,10 +155,10 @@ def extract_length_calc(high, low, _):
 
 
 def str_basic_length_calc(str_1):
-    return str_1.string_length
+    return str_1.length
 
 def int_to_str_length_calc(int_val): # pylint: disable=unused-argument
-    return ast.String.MAX_LENGTH
+    return 8*ast.String.MAX_LENGTH
 
 def str_replace_check(*args):
     str_1, str_2, _ = args
@@ -168,13 +168,13 @@ def str_replace_check(*args):
 
 def substr_length_calc(start_idx, count, strval): # pylint: disable=unused-argument
     # FIXME: How can I get the value of a concrete object without a solver
-    return strval.string_length if not count.concrete else count.args[0]
+    return strval.length if not count.concrete else 8*count.args[0]
 
 def ext_length_calc(ext, orig):
     return orig.length + ext
 
 def str_concat_length_calc(*args):
-    return sum(arg.string_length for arg in args)
+    return sum(arg.length for arg in args)
 
 def str_replace_length_calc(*args):
     str_1, str_2, str_3 = args
@@ -184,10 +184,10 @@ def str_replace_length_calc(*args):
     # If the part that has to be replaced if greater than
     # the replacement than the we have the maximum length possible
     # when the part that has to be replaced is not found inside the string
-    if str_2.string_length >= str_3.string_length:
-        return str_1.string_length
+    if str_2.length >= str_3.length:
+        return str_1.length
     # Otherwise We have the maximum length when teh replacement happens
-    return str_1.string_length - str_2.string_length + str_3.string_length
+    return str_1.length - str_2.length + str_3.length
 
 def strlen_bv_size_calc(s, bitlength): # pylint: disable=unused-argument
     return bitlength


### PR DESCRIPTION
Fix for: https://github.com/angr/claripy/issues/292

Warning: This changes the semantic meaning of `String.length` from byte length to bit length; use `.string_length` for byte length.

Also, `.size()` and `__len__` are both defined by `Bits`, they also change from byte to bit length; we can override these functions in the `String` class if we desire before merging this.