### PR TITLE
Fix ast/base.py hash issues

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -368,7 +368,7 @@ class Base:
         else:
             annotations = b'\xf9'
 
-        return op.encode() + serialized_args + Base._arg_serialize(minus0) + length + variables + symbolic + annotations
+        return op.encode() + serialized_args + length + variables + symbolic + annotations + Base._arg_serialize(minus0)
 
     #pylint:disable=attribute-defined-outside-init
     def __a_init__(self, op, args, variables=None, symbolic=None, length=None, simplified=0, errored=None,

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -61,7 +61,11 @@ def _d(h, cls, state):
     It exists to work around the fact that pickle will (normally) call __new__() with no arguments during deserialization.
     For ASTs, this does not work.
     """
-    op, args, length, variables, symbolic, annotations, minus0 = state
+    if len(state) == 6: # TODO: remove me
+        op, args, length, variables, symbolic, annotations = state
+        minus0 = False
+    else:
+        op, args, length, variables, symbolic, annotations, minus0 = state
     if minus0:
         args = (-0.0, *args[1:])
     return cls.__new__(cls, op, args, length=length, variables=variables, symbolic=symbolic, annotations=annotations, hash=h)
@@ -247,6 +251,7 @@ class Base:
     def __reduce__(self):
         # HASHCONS: these attributes key the cache
         # BEFORE CHANGING THIS, SEE ALL OTHER INSTANCES OF "HASHCONS" IN THIS FILE
+        breakpoint()
         return _d, (self._hash, self.__class__, (self.op, self.args, self.length, self.variables, self.symbolic, self.annotations, _minus_zero(self.op, self.args)))
 
     def __init__(self, *args, **kwargs):
@@ -339,7 +344,7 @@ class Base:
         return None
 
     @staticmethod
-    def _ast_serialize(op: str, args_tup, minus0, keywords) -> Optional[bytes]:
+    def _ast_serialize(op: str, args_tup, minus0: bool, keywords) -> Optional[bytes]:
         """
         Serialize the AST and get a bytestring for hashing.
 

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -61,11 +61,7 @@ def _d(h, cls, state):
     It exists to work around the fact that pickle will (normally) call __new__() with no arguments during deserialization.
     For ASTs, this does not work.
     """
-    if len(state) == 6: # TODO: remove me
-        op, args, length, variables, symbolic, annotations = state
-        minus0 = False
-    else:
-        op, args, length, variables, symbolic, annotations, minus0 = state
+    op, args, length, variables, symbolic, annotations, minus0 = state
     if minus0:
         args = (-0.0, *args[1:])
     return cls.__new__(cls, op, args, length=length, variables=variables, symbolic=symbolic, annotations=annotations, hash=h)

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -264,20 +264,19 @@ class Base:
         (hash(-1) == hash(-2), for example)
         """
         args_tup = tuple(a if type(a) in (int, float) else getattr(a, '_hash', hash(a)) for a in args)
+        ans = keywords.get('annotations', None)
+        length = keywords.get('length', None)
 
         # Adjustments to args_tup to force different hashes on known collisions
         if op == "FPV" and args_tup[0] == 0.0 and math.copysign(1, args_tup[0]) < 0:
             args_tup = args_tup + (-1,)
 
         # Fast path for leaves (also fix for +0.0 vs -0.0)
-        ans = keywords.get('annotations', None)
-        length = keywords.get('length', None)
         if op in {'BVS', 'BVV', 'BoolS', 'BoolV', 'FPS', 'FPV'} and not ans:
             return hash((op, length, args_tup))
 
         # HASHCONS: these attributes key the cache
         # BEFORE CHANGING THIS, SEE ALL OTHER INSTANCES OF "HASHCONS" IN THIS FILE
-
         to_hash = Base._ast_serialize(op, args_tup, keywords)
         if to_hash is None:
             # fall back to pickle.dumps
@@ -619,7 +618,7 @@ class Base:
         :returns:                   A string representing the AST
         """
         if max_depth is not None and max_depth <= 0:
-                return '<...>'
+            return '<...>'
 
         elif self.op in operations.reversed_ops:
             op = operations.reversed_ops[self.op]

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -279,7 +279,7 @@ class Base:
         else:
             # HASHCONS: these attributes key the cache
             # BEFORE CHANGING THIS, SEE ALL OTHER INSTANCES OF "HASHCONS" IN THIS FILE
-            to_hash = Base._ast_serialize(op, args_tup, keywords)
+            to_hash = Base._ast_serialize(op, args_tup, minus0, keywords)
             if to_hash is None:
                 # fall back to pickle.dumps
                 to_hash = (
@@ -339,12 +339,13 @@ class Base:
         return None
 
     @staticmethod
-    def _ast_serialize(op: str, args_tup, keywords) -> Optional[bytes]:
+    def _ast_serialize(op: str, args_tup, minus0, keywords) -> Optional[bytes]:
         """
         Serialize the AST and get a bytestring for hashing.
 
         :param op:          The operator.
         :param args_tup:    A tuple of arguments.
+        :param minus0:      A bool stating this is an FPV where args[0] is -0.0
         :param keywords:    A dict of keywords.
         :return:            The serialized bytestring.
         """
@@ -367,7 +368,7 @@ class Base:
         else:
             annotations = b'\xf9'
 
-        return op.encode() + serialized_args + length + variables + symbolic + annotations
+        return op.encode() + serialized_args + Base._arg_serialize(minus0) + length + variables + symbolic + annotations
 
     #pylint:disable=attribute-defined-outside-init
     def __a_init__(self, op, args, variables=None, symbolic=None, length=None, simplified=0, errored=None,

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -247,7 +247,6 @@ class Base:
     def __reduce__(self):
         # HASHCONS: these attributes key the cache
         # BEFORE CHANGING THIS, SEE ALL OTHER INSTANCES OF "HASHCONS" IN THIS FILE
-        breakpoint()
         return _d, (self._hash, self.__class__, (self.op, self.args, self.length, self.variables, self.symbolic, self.annotations, _minus_zero(self.op, self.args)))
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This fixes multiple issues:
1. Non-integer (and non-`str`) `._hash` values for ASTs. Notice how https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L226 can propagate to https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L239
Fundamentally, if `._hash` is never used as a hash of the AST, this isn't an issue; i.e. if only `hash(my_ast)` is used it is ok because we do convert in that function on demand. The problem is, that `._hash` is used as the hash.
2. Differing behavior if annotations exist / do not. At this if statement https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L218 notice we have special cases for floats like fixing the problem that `hash(0.0) == hash(-0.0)` here: https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L221 But this only happens if `not annotations`.
3. Fix anything that uses `_calc_hash` to determine what key to enter into a hash cache for looking up existing ASTs; since for some cases our cache uses the tuples made via our fast-path here: https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L218 Ex: https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L253
4. Reduce code duplication between `Base.__new__` and `Base.__init_with_annotations__`.
5. Fix a bug in `Base.__init_with_annotations__` where we didn't use the leaf cache at all and instead were looking for leaves in the non-leaf cache: https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L251
6. Non-reproducible hashes; since `self._hash` was not always calculated via `_calc_hash` but sometimes as a tuple (see point 1).
7. When deserializing via `base.py`'s `_d` function https://github.com/angr/claripy/blob/51d17532025b87fd7d6eafa6ca87fa23df4b800d/claripy/ast/base.py#L58 this bypasses the leaf cache and incorrectly stores the leaves in the non-leaf cache.
8. Serialization is incomplete; it looses information such as `+0.0` vs `-0.0`; thus deserialization may be incorrect.
9. (Unknown if applicable) If `_d` always takes an integer (or `str`) as a hash, deserialization will lead to ASTs with corrupt `_hash`s because of point 1.

Before merging:
- [ ] Add fastpath for annotation-free children (this was removed temporarily to get hashing work first)

Linked: https://github.com/angr/binaries/pull/101