### PR TITLE
expr: fix shift with negative operand

### DIFF
--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -181,19 +181,13 @@ class BVV(BackendObject):
     @normalize_types
     @compare_bits
     def __lshift__(self, o):
-        if o.signed < self.bits:
-            return BVV(self.value << o.signed, self.bits)
-        else:
-            return BVV(0, self.bits)
+        return BVV(self.value << o.value, self.bits)
 
     @normalize_types
     @compare_bits
     def __rshift__(self, o):
         # arithmetic shift uses the signed version
-        if o.signed < self.bits:
-            return BVV(self.signed >> o.signed, self.bits)
-        else:
-            return BVV(0, self.bits)
+        return BVV(self.signed >> o.value, self.bits)
 
     def __invert__(self):
         return BVV(self.value ^ self.mod-1, self.bits)
@@ -441,4 +435,4 @@ def If(c, t, f):
 @normalize_types
 @compare_bits
 def LShR(a, b):
-    return BVV(a.value >> b.signed, a.bits)
+    return BVV(a.value >> b.value, a.bits)


### PR DESCRIPTION
related to #271 

when shifting a BV by a negative amount (as might happen when symbolically executing it), it throws a `ValueError: negative shift count` because the count is taken as signed. that should not be the case and this PR fixes that.

also added a bunch of test for the various shift behavior.

btw, I didn't keep the `o.signed < self.bits` branch, as the value is already sanitized in `__init__`, but maybe I missed smth?