### PR TITLE
Condense min/max into singular function

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -858,12 +858,8 @@ class BackendZ3(Backend):
         """
         global solve_count
 
-        if signed:
-            lo = -2**(expr.size()-1)
-            hi = 2**(expr.size()-1)-1
-        else:
-            lo = 0
-            hi = 2**expr.size()-1
+        lo = -2**(expr.size()-1) if signed else 0
+        hi = 2**(expr.size()-1)-1 if signed else 2**expr.size()-1
 
         extra_constraints_converted = [self.convert(e) for e in extra_constraints]
         comment = "max" if is_max else "min"

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -32,7 +32,7 @@ def handle_sigint(signals, frametype):
     if callable(old_handler):
         old_handler(signals, frametype)
     else:
-        print("*** CRITICAL ERROR - THIS SHOULD NEVER HAPPEN")
+        print("*** CRITICAL ERROR - THIS SHOULD NEVER HAPPEN", sys.stderr, flush=True)
         raise KeyboardInterrupt()
 
 if threading.current_thread() == threading.main_thread():  # Signal only works in the main thread
@@ -856,7 +856,7 @@ class BackendZ3(Backend):
         """
         _max if is_max else _min
         """
-        global solve_count
+        global solve_count # pylint: disable=global-statement
 
         lo = -2**(expr.size()-1) if signed else 0
         hi = 2**(expr.size()-1)-1 if signed else 2**expr.size()-1
@@ -868,8 +868,6 @@ class BackendZ3(Backend):
         LE = operator.le if signed else z3.ULE
 
         # TODO: Can only deal with bitvectors, not floats
-        qqq = 0
-        print("\n"*3 + f"Max: {is_max}\nSigned: {signed}\nExpr: {expr}\n\tType: {type(expr)}\n\tSize: {expr.size()}\nExtra constraints: {extra_constraints}\nSolver: {solver}\n\tConstraints: {solver.assertions()}")
         while hi-lo > 1:
             middle = (lo + hi)//2
             #l.debug("h/m/l/d: %d %d %d %d", hi, middle, lo, hi-lo)
@@ -892,18 +890,10 @@ class BackendZ3(Backend):
                     model_callback(self._generic_model(solver.model()))
             else:
                 l.debug("... now unsat")
-            print(f"\t\t{hi}\t{middle}\t{lo}")
             if sat == is_max:
                 lo = middle
             else:
                 hi = middle
-            qqq += 1
-            if qqq > (expr.size() + 2):
-                print("Hung: ")
-                print(solver)
-                print(extra_constraints)
-                print("Cannot find extrema: ", expr)
-                raise ValueError("fail here")
 
         constraints.append(expr == (hi if is_max else lo))
         sat = z3_solver_sat(solver, constraints, comment)
@@ -913,7 +903,6 @@ class BackendZ3(Backend):
             ret = hi
         else:
             ret = lo
-        print(f"End: {ret}")
         return ret
 
 

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -863,7 +863,6 @@ class BackendZ3(Backend):
 
         constraints = [self.convert(e) for e in extra_constraints]
         comment = "max" if is_max else "min"
-        new_constraints = []
 
         GE = operator.ge if signed else z3.UGE
         LE = operator.le if signed else z3.ULE

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import ctypes
 import logging
 import numbers
@@ -789,7 +790,7 @@ class BackendZ3(Backend):
         return model
 
     def _satisfiable(self, extra_constraints=(), solver=None, model_callback=None):
-        global solve_count
+        global solve_count  # pylint: disable=global-statement
 
         solve_count += 1
 
@@ -812,7 +813,7 @@ class BackendZ3(Backend):
 
     @condom
     def _batch_eval(self, exprs, n, extra_constraints=(), solver=None, model_callback=None):
-        global solve_count
+        global solve_count  # pylint: disable=global-statement
 
         result_values = [ ]
 

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -900,17 +900,13 @@ class BackendZ3(Backend):
             else:
                 hi = middle
 
-        if hi == lo:
+        sat = z3_solver_sat(solver, extra_constraints_converted + [expr == (hi if is_max else lo)], comment)
+        if sat and model_callback is not None:
+            model_callback(self._generic_model(solver.model()))
+        if sat == is_max:
             ret = hi
         else:
-            sat = z3_solver_sat(solver, extra_constraints_converted + [expr == (hi if is_max else lo)], comment)
-            if sat and model_callback is not None:
-                model_callback(self._generic_model(solver.model()))
-            if sat == is_max:
-                ret = hi
-            else:
-                ret = lo
-
+            ret = lo
         return ret
 
 

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -869,6 +869,8 @@ class BackendZ3(Backend):
         LE = operator.le if signed else z3.ULE
 
         # TODO: Can only deal with bitvectors, not floats
+        qqq = 0
+        print("\n"*3 + f"Max: {is_max}\nSigned: {signed}\nExpr: {expr}\n\tType: {type(expr)}\n\tSize: {expr.size()}\nExtra constraints: {extra_constraints}\nSolver: {solver}\n\tConstraints: {solver.assertions()}")
         while hi-lo > 1:
             middle = (lo + hi)//2
             #l.debug("h/m/l/d: %d %d %d %d", hi, middle, lo, hi-lo)
@@ -891,10 +893,18 @@ class BackendZ3(Backend):
             else:
                 l.debug("... now unsat")
                 new_constraints.pop()
+            print(f"\t\t{hi}\t{middle}\t{lo}")
             if sat == is_max:
                 lo = middle
             else:
                 hi = middle
+            qqq += 1
+            if qqq > (expr.size() + 2):
+                print("Hung: ")
+                print(solver)
+                print(extra_constraints)
+                print("Cannot find extrema: ", expr)
+                raise ValueError("fail here")
 
         sat = z3_solver_sat(solver, extra_constraints_converted + [expr == (hi if is_max else lo)], comment)
         if sat and model_callback is not None:
@@ -903,6 +913,7 @@ class BackendZ3(Backend):
             ret = hi
         else:
             ret = lo
+        print(f"End: {ret}")
         return ret
 
 

--- a/tests/test_z3.py
+++ b/tests/test_z3.py
@@ -14,8 +14,15 @@ class TestZ3(unittest.TestCase):
         assert z.max(x, solver=s) == rng[1]
 
         for i in range(rng[0], rng[1] + 1):
+            # ==
             assert z.min(x, solver=s, extra_constraints=(x == i,)) == i
             assert z.max(x, solver=s, extra_constraints=(x == i,)) == i
+            # <=
+            assert z.min(x, solver=s, extra_constraints=(x <= i,)) == rng[0]
+            assert z.max(x, solver=s, extra_constraints=(x <= i,)) == i
+            # >=
+            assert z.min(x, solver=s, extra_constraints=(x >= i,)) == i
+            assert z.max(x, solver=s, extra_constraints=(x >= i,)) == rng[1]
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_z3.py
+++ b/tests/test_z3.py
@@ -1,8 +1,16 @@
 import unittest
 import claripy
 
+
 class TestZ3(unittest.TestCase):
-    def test_extrema(self):
+    """
+    A class used for testing z3
+    """
+    @staticmethod
+    def test_extrema():
+        """
+        Test the _extrema function within the z3 backend
+        """
         z = claripy.backend_manager.backends.z3
 
         s = z.solver()
@@ -23,6 +31,7 @@ class TestZ3(unittest.TestCase):
             # >=
             assert z.min(x, solver=s, extra_constraints=(x >= i,)) == i
             assert z.max(x, solver=s, extra_constraints=(x >= i,)) == rng[1]
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_z3.py
+++ b/tests/test_z3.py
@@ -1,0 +1,21 @@
+import unittest
+import claripy
+
+class TestZ3(unittest.TestCase):
+    def test_extrema(self):
+        z = claripy.backend_manager.backends.z3
+
+        s = z.solver()
+        x = claripy.BVS("x", 8)
+
+        rng = (0, 2**x.length - 1,)
+        assert z.satisfiable(solver=s)
+        assert z.min(x, solver=s) == rng[0]
+        assert z.max(x, solver=s) == rng[1]
+
+        for i in range(rng[0], rng[1] + 1):
+            assert z.min(x, solver=s, extra_constraints=(x == i,)) == i
+            assert z.max(x, solver=s, extra_constraints=(x == i,)) == i
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR:
1. Condenses min/max into a single function body to avoid code duplication
2. Fixes the bug where `_max` uses `GT` instead of `GE` like min does.
3. Only keeps the latest binary search constraint during the search rather than every previously valid constraint; this should greatly decrease the number of constraints passed to Z3.