### PR TITLE
Pass Z3 StringVs with implicit zero pads explicitly

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -352,7 +352,7 @@ class BackendZ3(Backend):
 
     @condom
     def StringV(self, ast):
-        return z3.StringVal(ast.args[0], ctx=self._context)
+        return z3.StringVal(ast.args[0].ljust(ast.args[1], '\0'), ctx=self._context)
 
     @condom
     def StringS(self, ast):


### PR DESCRIPTION
Fixes: https://github.com/angr/claripy/issues/315