### PR TITLE
Pyupgrade

### DIFF
--- a/claripy/__init__.py
+++ b/claripy/__init__.py
@@ -65,7 +65,7 @@ _backend_manager.backends._register_backend(_backends_module.BackendVSA(), 'vsa'
 if not os.environ.get('WORKER', False) and os.environ.get('REMOTE', False):
     try:
         _backend_z3 = _backends_module.backendremote.BackendRemote()
-    except socket.error:
+    except OSError:
         raise ImportError("can't connect to backend")
 else:
     _backend_z3 = _backends_module.BackendZ3()

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -40,7 +40,7 @@ class ASTCacheKey:
         return type(self) is type(other) and self.ast._hash == other.ast._hash
 
     def __repr__(self):
-        return '<Key {} {}>'.format(self.ast._type_name(), self.ast.__repr__(inner=True))
+        return f'<Key {self.ast._type_name()} {self.ast.__repr__(inner=True)}>'
 
 #
 # AST variable naming
@@ -954,7 +954,7 @@ class Base:
         if not isinstance(old, Base) or not isinstance(new, Base):
             raise ClaripyReplacementError('replacements must be AST nodes')
         if type(old) is not type(new):
-            raise ClaripyReplacementError('cannot replace type {} ast with type {} ast'.format(type(old), type(new)))
+            raise ClaripyReplacementError(f'cannot replace type {type(old)} ast with type {type(new)} ast')
 
     def _identify_vars(self, all_vars, counter):
         if self.op == 'BVS':

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -40,7 +40,7 @@ class ASTCacheKey:
         return type(self) is type(other) and self.ast._hash == other.ast._hash
 
     def __repr__(self):
-        return '<Key %s %s>' % (self.ast._type_name(), self.ast.__repr__(inner=True))
+        return '<Key {} {}>'.format(self.ast._type_name(), self.ast.__repr__(inner=True))
 
 #
 # AST variable naming
@@ -230,7 +230,7 @@ class Base:
             h = Base._calc_hash(op, a_args, kwargs) if hash is None else hash
         self = cache.get(h, None)
         if self is None:
-            self = super(Base, cls).__new__(cls)
+            self = super().__new__(cls)
             depth = arg_max_depth + 1
             self.__a_init__(op, a_args, depth=depth,
                             uneliminatable_annotations=uneliminatable_annotations,
@@ -653,7 +653,7 @@ class Base:
         inner_repr = self._op_repr(op, args, inner, length, details, inner_infix_use_par)
 
         if not inner:
-            return "<{} {}>".format(self._type_name(), inner_repr)
+            return f"<{self._type_name()} {inner_repr}>"
         else:
             return inner_repr
 
@@ -689,27 +689,27 @@ class Base:
 
         if details < Base.MID_REPR:
             if op == 'If':
-                value = 'if {} then {} else {}'.format(args[0], args[1], args[2])
-                return '({})'.format(value) if inner else value
+                value = f'if {args[0]} then {args[1]} else {args[2]}'
+                return f'({value})' if inner else value
 
             elif op == 'Not':
-                return '!{}'.format(args[0])
+                return f'!{args[0]}'
 
             elif op == 'Extract':
-                return '{}[{}:{}]'.format(args[2], args[0], args[1])
+                return f'{args[2]}[{args[0]}:{args[1]}]'
 
             elif op == 'ZeroExt':
-                value = '0#{} .. {}'.format(args[0], args[1])
-                return '({})'.format(value) if inner else value
+                value = f'0#{args[0]} .. {args[1]}'
+                return f'({value})' if inner else value
 
             elif op in operations.prefix:
                 assert len(args) == 1
-                value = '{}{}'.format(operations.prefix[op], args[0])
-                return '({})'.format(value) if inner and inner_infix_use_par else value
+                value = f'{operations.prefix[op]}{args[0]}'
+                return f'({value})' if inner and inner_infix_use_par else value
 
             elif op in operations.infix:
-                value = ' {} '.format(operations.infix[op]).join(args)
-                return '({})'.format(value) if inner and inner_infix_use_par else value
+                value = f' {operations.infix[op]} '.join(args)
+                return f'({value})' if inner and inner_infix_use_par else value
 
         return '{}({})'.format(op, ', '.join(map(str, args)))
 
@@ -954,7 +954,7 @@ class Base:
         if not isinstance(old, Base) or not isinstance(new, Base):
             raise ClaripyReplacementError('replacements must be AST nodes')
         if type(old) is not type(new):
-            raise ClaripyReplacementError('cannot replace type %s ast with type %s ast' % (type(old), type(new)))
+            raise ClaripyReplacementError('cannot replace type {} ast with type {} ast'.format(type(old), type(new)))
 
     def _identify_vars(self, all_vars, counter):
         if self.op == 'BVS':

--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -103,13 +103,13 @@ def If(*args):
             convert = getattr(ty, '_from_' + type(args[1]).__name__)
             args[1] = convert(args[2], args[1])
         else:
-            raise ClaripyTypeError("can't convert {} to {}".format(type(args[1]), ty))
+            raise ClaripyTypeError(f"can't convert {type(args[1])} to {ty}")
     if not isinstance(args[2], ty):
         if hasattr(ty, '_from_' + type(args[2]).__name__):
             convert = getattr(ty, '_from_' + type(args[2]).__name__)
             args[2] = convert(args[1], args[2])
         else:
-            raise ClaripyTypeError("can't convert {} to {}".format(type(args[2]), ty))
+            raise ClaripyTypeError(f"can't convert {type(args[2])} to {ty}")
 
     if is_true(args[0]):
         return args[1].append_annotations(args[0].annotations)

--- a/claripy/backends/__init__.py
+++ b/claripy/backends/__init__.py
@@ -765,7 +765,7 @@ class Backend:
 
     def default_op(self, expr):
         # pylint: disable=unused-argument
-        raise BackendError('Backend {} does not support operation {}'.format(self, expr.op))
+        raise BackendError(f'Backend {self} does not support operation {expr.op}')
 
 from ..errors import BackendError, ClaripyRecursionError, BackendUnsupportedError
 from .backend_z3 import BackendZ3

--- a/claripy/backends/__init__.py
+++ b/claripy/backends/__init__.py
@@ -765,7 +765,7 @@ class Backend:
 
     def default_op(self, expr):
         # pylint: disable=unused-argument
-        raise BackendError('Backend %s does not support operation %s' % (self, expr.op))
+        raise BackendError('Backend {} does not support operation {}'.format(self, expr.op))
 
 from ..errors import BackendError, ClaripyRecursionError, BackendUnsupportedError
 from .backend_z3 import BackendZ3

--- a/claripy/backends/backend_concrete.py
+++ b/claripy/backends/backend_concrete.py
@@ -141,7 +141,7 @@ class BackendConcrete(Backend):
         elif isinstance(e, strings.StringV):
             return StringV(e.value)
         else:
-            raise BackendError("Couldn't abstract object of type {}".format(type(e)))
+            raise BackendError(f"Couldn't abstract object of type {type(e)}")
 
     def _cardinality(self, b):
         # if we got here, it's a cardinality of 1

--- a/claripy/backends/backend_smtlib.py
+++ b/claripy/backends/backend_smtlib.py
@@ -28,7 +28,7 @@ def _expr_to_smtlib(e, daggify=True):
     :return string: smt-lib representation of the symbol
     """
     if e.is_symbol():
-        return "(declare-fun {} {})".format(e.symbol_name(), e.symbol_type().as_smtlib())
+        return f"(declare-fun {e.symbol_name()} {e.symbol_type().as_smtlib()})"
     else:
         return "(assert %s)" % e.to_smtlib(daggify=daggify)
 

--- a/claripy/backends/backend_smtlib.py
+++ b/claripy/backends/backend_smtlib.py
@@ -28,7 +28,7 @@ def _expr_to_smtlib(e, daggify=True):
     :return string: smt-lib representation of the symbol
     """
     if e.is_symbol():
-        return "(declare-fun %s %s)" % (e.symbol_name(), e.symbol_type().as_smtlib())
+        return "(declare-fun {} {})".format(e.symbol_name(), e.symbol_type().as_smtlib())
     else:
         return "(assert %s)" % e.to_smtlib(daggify=daggify)
 

--- a/claripy/backends/backend_smtlib_solvers/__init__.py
+++ b/claripy/backends/backend_smtlib_solvers/__init__.py
@@ -12,7 +12,7 @@ from pysmt.smtlib.parser import Tokenizer
 from pysmt.shortcuts import NotEquals
 
 
-class AbstractSMTLibSolverProxy(object):
+class AbstractSMTLibSolverProxy:
     def write(self, smt):
         raise NotImplementedError
 
@@ -50,7 +50,7 @@ class AbstractSMTLibSolverProxy(object):
 
 class PopenSolverProxy(AbstractSMTLibSolverProxy):
     def __init__(self, p):
-        super(PopenSolverProxy, self).__init__()
+        super().__init__()
         self.p = p
         self.constraints = []
 
@@ -77,7 +77,7 @@ class SMTLibSolverBackend(BackendSMTLibBase):
     def __init__(self, *args, **kwargs):
         kwargs['solver_required'] = True
         self.smt_script_log_dir = kwargs.pop('smt_script_log_dir', None)
-        super(SMTLibSolverBackend, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def solver(self, timeout=None, max_memory=None): #pylint:disable=no-self-use,unused-argument
         """
@@ -119,7 +119,7 @@ class SMTLibSolverBackend(BackendSMTLibBase):
         smt_script = self._get_satisfiability_smt_script(constraints=csts, variables=vars)
 
         if self.smt_script_log_dir is not None:
-            fname = 'check-sat_{}.smt2'.format(hashlib.md5(smt_script.encode()).hexdigest())
+            fname = f'check-sat_{hashlib.md5(smt_script.encode()).hexdigest()}.smt2'
 
             with open(os.path.join(self.smt_script_log_dir, fname), 'wb') as f:
                 f.write(smt_script.encode())
@@ -129,7 +129,7 @@ class SMTLibSolverBackend(BackendSMTLibBase):
 
         sat = solver.read_sat().upper()
         if sat not in {'SAT', 'UNSAT', 'UNKNOWN'}:
-            raise ValueError("Solver error, don't understand (check-sat) response: {}".format(repr(sat)))
+            raise ValueError(f"Solver error, don't understand (check-sat) response: {repr(sat)}")
         return sat.upper()
 
     def _check_satisfiability(self, extra_constraints=(), solver=None, model_callback=None, extra_variables=()):
@@ -147,7 +147,7 @@ class SMTLibSolverBackend(BackendSMTLibBase):
         vars, csts = self._get_all_vars_and_constraints(solver=solver, e_c=extra_constraints, e_v=extra_variables)
         smt_script = self._get_full_model_smt_script(constraints=csts, variables=vars)
         if self.smt_script_log_dir is not None:
-            fname = 'get-model_{}.smt2'.format(hashlib.md5(smt_script.encode()).hexdigest())
+            fname = f'get-model_{hashlib.md5(smt_script.encode()).hexdigest()}.smt2'
             with open(os.path.join(self.smt_script_log_dir, fname), 'wb') as f:
                 f.write(smt_script.encode())
 

--- a/claripy/backends/backend_smtlib_solvers/abc_popen.py
+++ b/claripy/backends/backend_smtlib_solvers/abc_popen.py
@@ -18,9 +18,9 @@ def get_version():
         return True, None, None # True, version_match.group(1), None
 
     except subprocess.CalledProcessError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
     except OSError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
 
 
 IS_INSTALLED, VERSION, ERROR = get_version()
@@ -29,7 +29,7 @@ class ABCProxy(PopenSolverProxy):
     def __init__(self):
         self.installed = False
         p = None
-        super(ABCProxy, self).__init__(p)
+        super().__init__(p)
 
     def create_process(self):
         if not IS_INSTALLED:

--- a/claripy/backends/backend_smtlib_solvers/cvc4_popen.py
+++ b/claripy/backends/backend_smtlib_solvers/cvc4_popen.py
@@ -13,14 +13,14 @@ def get_version():
         version_match = re.match('This is CVC4 version (.*)\n', version_string)
 
         if not version_match:
-            return False, None, "Found malformed version string: {}".format(version_string)
+            return False, None, f"Found malformed version string: {version_string}"
 
         return True, version_match.group(1), None
 
     except subprocess.CalledProcessError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
     except OSError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
 
 
 IS_INSTALLED, VERSION, ERROR = get_version()
@@ -32,7 +32,7 @@ class CVC4Proxy(PopenSolverProxy):
         self.max_memory = max_memory  # TODO: not used
         self.installed = False
         p = None
-        super(CVC4Proxy, self).__init__(p)
+        super().__init__(p)
 
     def create_process(self):
         # spawn the subprocess
@@ -40,7 +40,7 @@ class CVC4Proxy(PopenSolverProxy):
             raise MissingSolverError('CVC4 not found! Please install CVC4 before using this backend')
         cmd = ['cvc4', '--lang=smt', '-q', '--strings-exp']
         if self.timeout is not None:
-            cmd += ['--tlimit-per={}'.format(self.timeout)]
+            cmd += [f'--tlimit-per={self.timeout}']
         p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.installed = True
         return p

--- a/claripy/backends/backend_smtlib_solvers/z3_popen.py
+++ b/claripy/backends/backend_smtlib_solvers/z3_popen.py
@@ -13,14 +13,14 @@ def get_version():
         version_match = re.match('Z3 version (.*)\n', version_string)
 
         if not version_match:
-            return False, None, "Found malformed version string: {}".format(version_string)
+            return False, None, f"Found malformed version string: {version_string}"
 
         return True, version_match.group(1), None
 
     except subprocess.CalledProcessError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
     except OSError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
 
 
 IS_INSTALLED, VERSION, ERROR = get_version()
@@ -31,16 +31,16 @@ class Z3Proxy(PopenSolverProxy):
         self.max_memory = max_memory
         self.installed = False
         p = None
-        super(Z3Proxy, self).__init__(p)
+        super().__init__(p)
 
     def create_process(self):
         if not IS_INSTALLED:
             raise MissingSolverError('Z3 not found! Please install Z3 before using this backend')
         cmd = ['z3', '-smt2', '-in']
         if self.timeout is not None:
-            cmd.append('-t:{}'.format(self.timeout//1000))  # our timeout is in milliseconds
+            cmd.append(f'-t:{self.timeout//1000}')  # our timeout is in milliseconds
         if self.max_memory is not None:
-            cmd.append('-memory:{}'.format(self.max_memory))
+            cmd.append(f'-memory:{self.max_memory}')
 
         p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.installed = True

--- a/claripy/backends/backend_smtlib_solvers/z3str_popen.py
+++ b/claripy/backends/backend_smtlib_solvers/z3str_popen.py
@@ -13,14 +13,14 @@ def get_version():
         version_match = re.match('Z3 version (.*)\n', version_string)
 
         if not version_match:
-            return False, None, "Found malformed version string: {}".format(version_string)
+            return False, None, f"Found malformed version string: {version_string}"
 
         return True, version_match.group(1), None
 
     except subprocess.CalledProcessError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
     except OSError as ex:
-        return False, None, "Not found, error: {}".format(ex)
+        return False, None, f"Not found, error: {ex}"
 
 
 IS_INSTALLED, VERSION, ERROR = get_version()
@@ -31,16 +31,16 @@ class Z3StrProxy(PopenSolverProxy):
         self.max_memory = max_memory
         self.installed = False
         p = None
-        super(Z3StrProxy, self).__init__(p)
+        super().__init__(p)
 
     def create_process(self):
         if not IS_INSTALLED:
             raise MissingSolverError('Z3str not found! Please install Z3str before using this backend')
         cmd = ['z3', '-smt2', 'smt.string_solver=z3str3', '-in']
         if self.timeout is not None:
-            cmd.append('-t:{}'.format(self.timeout//1000))  # our timeout is in milliseconds
+            cmd.append(f'-t:{self.timeout//1000}')  # our timeout is in milliseconds
         if self.max_memory is not None:
-            cmd.append('-memory:{}'.format(self.max_memory))
+            cmd.append(f'-memory:{self.max_memory}')
 
         p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.installed = False

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -745,7 +745,7 @@ class BackendZ3(Backend):
 
     def _add(self, s, c, track=False):
         if track:
-            already_tracked = set(str(impl.children()[0]) for impl in s.assertions())
+            already_tracked = {str(impl.children()[0]) for impl in s.assertions()}
             for constraint in c:
                 name = str(hash(constraint))
                 if name not in already_tracked:

--- a/claripy/debug.py
+++ b/claripy/debug.py
@@ -1,4 +1,3 @@
-
 # to enable debug mode, please set _DEBUG to True via the set_debug method.
 _DEBUG = True
 

--- a/claripy/fp.py
+++ b/claripy/fp.py
@@ -12,7 +12,7 @@ def compare_sorts(f):
     @functools.wraps(f)
     def compare_guard(self, o):
         if self.sort != o.sort:
-            raise TypeError("FPVs are differently-sorted ({} and {})".format(self.sort, o.sort))
+            raise TypeError(f"FPVs are differently-sorted ({self.sort} and {o.sort})")
         return f(self, o)
 
     return compare_guard
@@ -86,7 +86,7 @@ class FSort:
         elif n == 64:
             return FSORT_DOUBLE
         else:
-            raise ClaripyOperationError('{} is not a valid FSort size'.format(n))
+            raise ClaripyOperationError(f'{n} is not a valid FSort size')
 
     @staticmethod
     def from_params(exp, mantissa):
@@ -236,7 +236,7 @@ class FPV(BackendObject):
         return self.value >= o.value
 
     def __repr__(self):
-        return 'FPV({:f}, {})'.format(self.value, self.sort)
+        return f'FPV({self.value:f}, {self.sort})'
 
 def fpToFP(a1, a2, a3=None):
     """
@@ -345,7 +345,7 @@ def fpToSBV(rm, fp, size):
     except (ValueError, OverflowError):
         return BVV(0, size)
     except Exception as ex:
-        print("Unhandled error during floating point rounding! {}".format(ex))
+        print(f"Unhandled error during floating point rounding! {ex}")
         raise
 
 def fpToUBV(rm, fp, size):

--- a/claripy/frontend_mixins/composited_cache_mixin.py
+++ b/claripy/frontend_mixins/composited_cache_mixin.py
@@ -4,15 +4,15 @@
 
 class CompositedCacheMixin:
     def __init__(self, *args, **kwargs):
-        super(CompositedCacheMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._merged_solvers = { }
 
     def _blank_copy(self, c):
-        super(CompositedCacheMixin, self)._blank_copy(c)
+        super()._blank_copy(c)
         c._merged_solvers = { }
 
     def _copy(self, c):
-        super(CompositedCacheMixin, self)._copy(c)
+        super()._copy(c)
         c._merged_solvers = dict(self._merged_solvers)
 
     def __setstate__(self, base_state):
@@ -41,14 +41,14 @@ class CompositedCacheMixin:
             return r
         except KeyError:
             #misses += 1
-            s = super(CompositedCacheMixin, self)._solver_for_names(names)
+            s = super()._solver_for_names(names)
             self._merged_solvers[n] = s
             return s
 
     def downsize(self):
-        super(CompositedCacheMixin, self).downsize()
+        super().downsize()
         self._merged_solvers = { }
 
     def _store_child(self, s, **kwargs):
         self._remove_cached(s.variables)
-        return super(CompositedCacheMixin, self)._store_child(s, **kwargs)
+        return super()._store_child(s, **kwargs)

--- a/claripy/frontend_mixins/concrete_handler_mixin.py
+++ b/claripy/frontend_mixins/concrete_handler_mixin.py
@@ -4,7 +4,7 @@ class ConcreteHandlerMixin:
         if c is not None:
             return (c,)
         else:
-            return super(ConcreteHandlerMixin, self).eval(e, n, **kwargs)
+            return super().eval(e, n, **kwargs)
 
     def batch_eval(self, exprs, n, **kwargs): #pylint:disable=unused-argument
         concrete_exprs = [ self._concrete_value(e) for e in exprs ]
@@ -15,7 +15,7 @@ class ConcreteHandlerMixin:
 
         symbolic_results = map(
             list,
-            super(ConcreteHandlerMixin, self).batch_eval(symbolic_exprs, n, **kwargs)
+            super().batch_eval(symbolic_exprs, n, **kwargs)
         )
         return [
             tuple((c if c is not None else r.pop(0)) for c in concrete_exprs)
@@ -27,21 +27,21 @@ class ConcreteHandlerMixin:
         if c is not None:
             return c
         else:
-            return super(ConcreteHandlerMixin, self).max(e, **kwargs)
+            return super().max(e, **kwargs)
 
     def min(self, e, **kwargs):
         c = self._concrete_value(e)
         if c is not None:
             return c
         else:
-            return super(ConcreteHandlerMixin, self).min(e, **kwargs)
+            return super().min(e, **kwargs)
 
     def solution(self, e, v, **kwargs):
         ce = self._concrete_value(e)
         cv = self._concrete_value(v)
 
         if ce is None or cv is None:
-            return super(ConcreteHandlerMixin, self).solution(e, v, **kwargs)
+            return super().solution(e, v, **kwargs)
         else:
             return ce == cv
 
@@ -50,11 +50,11 @@ class ConcreteHandlerMixin:
         if c is not None:
             return c
         else:
-            return super(ConcreteHandlerMixin, self).is_true(e, **kwargs)
+            return super().is_true(e, **kwargs)
 
     def is_false(self, e, **kwargs):
         c = self._concrete_value(e)
         if c is not None:
             return not c
         else:
-            return super(ConcreteHandlerMixin, self).is_false(e, **kwargs)
+            return super().is_false(e, **kwargs)

--- a/claripy/frontend_mixins/constraint_deduplicator_mixin.py
+++ b/claripy/frontend_mixins/constraint_deduplicator_mixin.py
@@ -1,14 +1,14 @@
 class ConstraintDeduplicatorMixin:
     def __init__(self, *args, **kwargs):
-        super(ConstraintDeduplicatorMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._constraint_hashes = set()
 
     def _blank_copy(self, c):
-        super(ConstraintDeduplicatorMixin, self)._blank_copy(c)
+        super()._blank_copy(c)
         c._constraint_hashes = set()
 
     def _copy(self, c):
-        super(ConstraintDeduplicatorMixin, self)._copy(c)
+        super()._copy(c)
         c._constraint_hashes = set(self._constraint_hashes)
 
     def __getstate__(self):
@@ -19,7 +19,7 @@ class ConstraintDeduplicatorMixin:
         super().__setstate__(base_state)
 
     def simplify(self, **kwargs):
-        added = super(ConstraintDeduplicatorMixin, self).simplify(**kwargs)
+        added = super().simplify(**kwargs)
         # we only add to the constraint hashes because we want to
         # prevent previous (now simplified) constraints from
         # being re-added
@@ -31,6 +31,6 @@ class ConstraintDeduplicatorMixin:
         if len(filtered) == 0:
             return filtered
 
-        added = super(ConstraintDeduplicatorMixin, self).add(filtered, **kwargs)
+        added = super().add(filtered, **kwargs)
         self._constraint_hashes.update(map(hash, added))
         return added

--- a/claripy/frontend_mixins/constraint_expansion_mixin.py
+++ b/claripy/frontend_mixins/constraint_expansion_mixin.py
@@ -5,7 +5,7 @@ l = logging.getLogger("claripy.frontends.cache_mixin")
 
 class ConstraintExpansionMixin:
     def eval(self, e, n, extra_constraints=(), exact=None, **kwargs):
-        results = super(ConstraintExpansionMixin, self).eval(
+        results = super().eval(
             e, n,
             extra_constraints=extra_constraints,
             exact=exact,
@@ -21,21 +21,21 @@ class ConstraintExpansionMixin:
         return results
 
     def max(self, e, extra_constraints=(), exact=None, signed=False, **kwargs):
-        m = super(ConstraintExpansionMixin, self).max(e, extra_constraints=extra_constraints, exact=exact,
+        m = super().max(e, extra_constraints=extra_constraints, exact=exact,
                                                       signed=signed, **kwargs)
         if len(extra_constraints) == 0:
             self.add([SLE(e, m) if signed else ULE(e, m)], invalidate_cache=False)
         return m
 
     def min(self, e, extra_constraints=(), exact=None, signed=False, **kwargs):
-        m = super(ConstraintExpansionMixin, self).min(e, extra_constraints=extra_constraints, exact=exact,
+        m = super().min(e, extra_constraints=extra_constraints, exact=exact,
                                                       signed=signed, **kwargs)
         if len(extra_constraints) == 0:
             self.add([SGE(e, m) if signed else UGE(e, m)], invalidate_cache=False)
         return m
 
     def solution(self, e, v, extra_constraints=(), exact=None, **kwargs):
-        b = super(ConstraintExpansionMixin, self).solution(
+        b = super().solution(
             e, v,
             extra_constraints=extra_constraints,
             exact=exact,

--- a/claripy/frontend_mixins/constraint_filter_mixin.py
+++ b/claripy/frontend_mixins/constraint_filter_mixin.py
@@ -6,7 +6,7 @@ class ConstraintFilterMixin:
         if len(constraints) == 0:
             return constraints
 
-        filtered = super(ConstraintFilterMixin, self)._constraint_filter(constraints, **kwargs)
+        filtered = super()._constraint_filter(constraints, **kwargs)
         ccs = [ self._concrete_constraint(c) for c in filtered ]
         if False in ccs:
             raise UnsatError("Constraints contain False.")
@@ -24,44 +24,44 @@ class ConstraintFilterMixin:
             return [ ]
 
         if len(ec) > 0:
-            return super(ConstraintFilterMixin, self).add(ec, **kwargs)
+            return super().add(ec, **kwargs)
         else:
             return [ ]
 
     def satisfiable(self, extra_constraints=(), **kwargs):
         try:
             ec = self._constraint_filter(extra_constraints)
-            return super(ConstraintFilterMixin, self).satisfiable(extra_constraints=ec, **kwargs)
+            return super().satisfiable(extra_constraints=ec, **kwargs)
         except UnsatError:
             return False
 
     def eval(self, e, n, extra_constraints=(), **kwargs):
         ec = self._constraint_filter(extra_constraints)
-        return super(ConstraintFilterMixin, self).eval(e, n, extra_constraints=ec, **kwargs)
+        return super().eval(e, n, extra_constraints=ec, **kwargs)
 
     def batch_eval(self, exprs, n, extra_constraints=(), **kwargs):
         ec = self._constraint_filter(extra_constraints)
-        return super(ConstraintFilterMixin, self).batch_eval(exprs, n, extra_constraints=ec, **kwargs)
+        return super().batch_eval(exprs, n, extra_constraints=ec, **kwargs)
 
     def max(self, e, extra_constraints=(), **kwargs):
         ec = self._constraint_filter(extra_constraints)
-        return super(ConstraintFilterMixin, self).max(e, extra_constraints=ec, **kwargs)
+        return super().max(e, extra_constraints=ec, **kwargs)
 
     def min(self, e, extra_constraints=(), **kwargs):
         ec = self._constraint_filter(extra_constraints)
-        return super(ConstraintFilterMixin, self).min(e, extra_constraints=ec, **kwargs)
+        return super().min(e, extra_constraints=ec, **kwargs)
 
     def solution(self, e, v, extra_constraints=(), **kwargs):
         ec = self._constraint_filter(extra_constraints)
-        return super(ConstraintFilterMixin, self).solution(e, v, extra_constraints=ec, **kwargs)
+        return super().solution(e, v, extra_constraints=ec, **kwargs)
 
     def is_true(self, e, extra_constraints=(), **kwargs):
         ec = self._constraint_filter(extra_constraints)
-        return super(ConstraintFilterMixin, self).is_true(e, extra_constraints=ec, **kwargs)
+        return super().is_true(e, extra_constraints=ec, **kwargs)
 
     def is_false(self, e, extra_constraints=(), **kwargs):
         ec = self._constraint_filter(extra_constraints)
-        return super(ConstraintFilterMixin, self).is_false(e, extra_constraints=ec, **kwargs)
+        return super().is_false(e, extra_constraints=ec, **kwargs)
 
 from ..errors import UnsatError, ClaripyValueError
 from .. import false

--- a/claripy/frontend_mixins/constraint_fixer_mixin.py
+++ b/claripy/frontend_mixins/constraint_fixer_mixin.py
@@ -6,6 +6,6 @@ class ConstraintFixerMixin:
             return [ ]
 
         constraints = [ BoolV(c) if isinstance(c, bool) else c for c in constraints ]
-        return super(ConstraintFixerMixin, self).add(constraints, **kwargs)
+        return super().add(constraints, **kwargs)
 
 from .. import BoolV

--- a/claripy/frontend_mixins/debug_mixin.py
+++ b/claripy/frontend_mixins/debug_mixin.py
@@ -33,10 +33,10 @@ def _debug_iterator(i):
 
 class DebugMixin:
     def __init__(self, *args, **kwargs):
-        super(DebugMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __getattribute__(self, a):
-        o = super(DebugMixin, self).__getattribute__(a)
+        o = super().__getattribute__(a)
         if a.startswith("__"):
             return o
         elif hasattr(o, '__call__'):

--- a/claripy/frontend_mixins/eager_resolution_mixin.py
+++ b/claripy/frontend_mixins/eager_resolution_mixin.py
@@ -1,6 +1,6 @@
 class EagerResolutionMixin:
     def _concrete_value(self, e):
-        r = super(EagerResolutionMixin, self)._concrete_value(e)
+        r = super()._concrete_value(e)
         if r is not None:
             return r
 

--- a/claripy/frontend_mixins/eval_string_to_ast_mixin.py
+++ b/claripy/frontend_mixins/eval_string_to_ast_mixin.py
@@ -1,8 +1,8 @@
-class EvalStringsToASTsMixin(object):
+class EvalStringsToASTsMixin:
     def eval_to_ast(self, e, n, extra_constraints=(), exact=None):
         if type(e) is String:
             return [StringV(v, ) for v in self.eval(e, n, extra_constraints=extra_constraints, exact=exact) ]
 
-        return super(EvalStringsToASTsMixin, self).eval_to_ast(e, n, extra_constraints=extra_constraints, exact=None)
+        return super().eval_to_ast(e, n, extra_constraints=extra_constraints, exact=None)
 
 from .. import String, StringV

--- a/claripy/frontend_mixins/model_cache_mixin.py
+++ b/claripy/frontend_mixins/model_cache_mixin.py
@@ -104,7 +104,7 @@ class ModelCache:
 
 class ModelCacheMixin:
     def __init__(self, *args, **kwargs):
-        super(ModelCacheMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._models = set()
         self._exhausted = False
         self._eval_exhausted = weakref.WeakSet()
@@ -114,7 +114,7 @@ class ModelCacheMixin:
         self._min_signed_exhausted = weakref.WeakSet()
 
     def _blank_copy(self, c):
-        super(ModelCacheMixin, self)._blank_copy(c)
+        super()._blank_copy(c)
         c._models = set()
         c._exhausted = False
         c._eval_exhausted = weakref.WeakSet()
@@ -124,7 +124,7 @@ class ModelCacheMixin:
         c._min_signed_exhausted = weakref.WeakSet()
 
     def _copy(self, c):
-        super(ModelCacheMixin, self)._copy(c)
+        super()._copy(c)
         c._models = set(self._models)
         c._exhausted = self._exhausted
         c._eval_exhausted = weakref.WeakSet(self._eval_exhausted)
@@ -148,7 +148,7 @@ class ModelCacheMixin:
     #
 
     def simplify(self, *args, **kwargs):
-        results = super(ModelCacheMixin, self).simplify(*args, **kwargs)
+        results = super().simplify(*args, **kwargs)
         if len(results) > 0 and any(c is false for c in results):
             self._models.clear()
         return results
@@ -178,7 +178,7 @@ class ModelCacheMixin:
             return constraints
 
         old_vars = frozenset(self.variables)
-        added = super(ModelCacheMixin, self).add(constraints, **kwargs)
+        added = super().add(constraints, **kwargs)
         if len(added) == 0:
             return added
 
@@ -204,13 +204,13 @@ class ModelCacheMixin:
         return added
 
     def split(self):
-        results = super(ModelCacheMixin, self).split()
+        results = super().split()
         for r in results:
             r._models = { m.filter(r.variables) for m in self._models }
         return results
 
     def combine(self, others):
-        combined = super(ModelCacheMixin, self).combine(others)
+        combined = super().combine(others)
 
         if any(len(o._models) == 0 for o in others) or len(self._models) == 0:
             # this would need a solve anyways, so screw it
@@ -251,7 +251,7 @@ class ModelCacheMixin:
     def _model_hook(self, m):
         # Z3 might give us solutions for variables that we did not ask for. so we create a new dict with solutions for
         # only the variables that are under the solver's control
-        m_ = dict((k, v) for k, v in m.items() if k in self.variables)
+        m_ = {k: v for k, v in m.items() if k in self.variables}
         if m_:
             model = ModelCache(m_)
             self._models.add(model)
@@ -288,7 +288,7 @@ class ModelCacheMixin:
     def satisfiable(self, extra_constraints=(), **kwargs):
         for _ in self._get_models(extra_constraints=extra_constraints):
             return True
-        return super(ModelCacheMixin, self).satisfiable(extra_constraints=extra_constraints, **kwargs)
+        return super().satisfiable(extra_constraints=extra_constraints, **kwargs)
 
     def batch_eval(self, asts, n, extra_constraints=(), **kwargs):
         results = self._get_batch_solutions(asts, n=n, extra_constraints=extra_constraints)
@@ -307,7 +307,7 @@ class ModelCacheMixin:
             constraints = extra_constraints
 
         try:
-            results.update(super(ModelCacheMixin, self).batch_eval(
+            results.update(super().batch_eval(
                 asts, remaining, extra_constraints=constraints, **kwargs
             ))
         except UnsatError:
@@ -337,7 +337,7 @@ class ModelCacheMixin:
             signed_key = lambda v: v if v < 2**(len(e)-1) else v - 2**len(e)
             return min(cached, key=signed_key if signed else lambda v: v)
         else:
-            m = super(ModelCacheMixin, self).min(e, extra_constraints=extra_constraints, signed=signed, **kwargs)
+            m = super().min(e, extra_constraints=extra_constraints, signed=signed, **kwargs)
             if len(extra_constraints) == 0:
                 (self._min_signed_exhausted if signed else self._min_exhausted).add(e.cache_key)
             return m
@@ -351,7 +351,7 @@ class ModelCacheMixin:
             signed_key = lambda v: v if v < 2**(len(e)-1) else v - 2**len(e)
             return max(cached, key=signed_key if signed else lambda v: v)
         else:
-            m = super(ModelCacheMixin, self).max(e, extra_constraints=extra_constraints, signed=signed, **kwargs)
+            m = super().max(e, extra_constraints=extra_constraints, signed=signed, **kwargs)
             if len(extra_constraints) == 0:
                 (self._max_signed_exhausted if signed else self._max_exhausted).add(e.cache_key)
             return m
@@ -366,7 +366,7 @@ class ModelCacheMixin:
             if v in cached:
                 return True
 
-        return super(ModelCacheMixin, self).solution(e, v, extra_constraints=extra_constraints, **kwargs)
+        return super().solution(e, v, extra_constraints=extra_constraints, **kwargs)
 
 
 from .. import backends, false

--- a/claripy/frontend_mixins/sat_cache_mixin.py
+++ b/claripy/frontend_mixins/sat_cache_mixin.py
@@ -1,14 +1,14 @@
 class SatCacheMixin:
     def __init__(self, *args, **kwargs):
-        super(SatCacheMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._cached_satness = None
 
     def _blank_copy(self, c):
-        super(SatCacheMixin, self)._blank_copy(c)
+        super()._blank_copy(c)
         c._cached_satness = None
 
     def _copy(self, c):
-        super(SatCacheMixin, self)._copy(c)
+        super()._copy(c)
         c._cached_satness = self._cached_satness
 
     def __getstate__(self):
@@ -23,7 +23,7 @@ class SatCacheMixin:
     #
 
     def add(self, constraints, **kwargs):
-        added = super(SatCacheMixin, self).add(constraints, **kwargs)
+        added = super().add(constraints, **kwargs)
         if len(added) > 0 and any(c is false for c in added):
             self._cached_satness = False
         elif self._cached_satness is True:
@@ -31,7 +31,7 @@ class SatCacheMixin:
         return added
 
     def simplify(self):
-        new_constraints = super(SatCacheMixin, self).simplify()
+        new_constraints = super().simplify()
         if len(new_constraints) > 0 and any(c is false for c in new_constraints):
             self._cached_satness = False
         return new_constraints
@@ -41,7 +41,7 @@ class SatCacheMixin:
             return False
         if self._cached_satness is True and len(extra_constraints) == 0:
             return True
-        r = super(SatCacheMixin, self).satisfiable(
+        r = super().satisfiable(
             extra_constraints=extra_constraints, **kwargs
         )
         if len(extra_constraints) == 0:
@@ -51,7 +51,7 @@ class SatCacheMixin:
     def eval(self, e, n, extra_constraints=(), **kwargs):
         if self._cached_satness is False: raise UnsatError("cached unsat")
         try:
-            r = super(SatCacheMixin, self).eval(
+            r = super().eval(
                 e, n,
                 extra_constraints=extra_constraints, **kwargs
             )
@@ -65,7 +65,7 @@ class SatCacheMixin:
     def batch_eval(self, e, n, extra_constraints=(), **kwargs):
         if self._cached_satness is False: raise UnsatError("cached unsat")
         try:
-            r = super(SatCacheMixin, self).batch_eval(
+            r = super().batch_eval(
                 e, n,
                 extra_constraints=extra_constraints, **kwargs
             )
@@ -79,7 +79,7 @@ class SatCacheMixin:
     def max(self, e, extra_constraints=(), **kwargs):
         if self._cached_satness is False: raise UnsatError("cached unsat")
         try:
-            r = super(SatCacheMixin, self).max(
+            r = super().max(
                 e,
                 extra_constraints=extra_constraints, **kwargs
             )
@@ -93,7 +93,7 @@ class SatCacheMixin:
     def min(self, e, extra_constraints=(), **kwargs):
         if self._cached_satness is False: raise UnsatError("cached unsat")
         try:
-            r = super(SatCacheMixin, self).min(
+            r = super().min(
                 e,
                 extra_constraints=extra_constraints, **kwargs
             )
@@ -107,7 +107,7 @@ class SatCacheMixin:
     def solution(self, e, v, extra_constraints=(), **kwargs):
         if self._cached_satness is False: raise UnsatError("cached unsat")
         try:
-            r = super(SatCacheMixin, self).solution(
+            r = super().solution(
                 e, v,
                 extra_constraints=extra_constraints, **kwargs
             )

--- a/claripy/frontend_mixins/simplify_helper_mixin.py
+++ b/claripy/frontend_mixins/simplify_helper_mixin.py
@@ -1,18 +1,18 @@
 class SimplifyHelperMixin:
     def max(self, *args, **kwargs):
         self.simplify()
-        return super(SimplifyHelperMixin, self).max(*args, **kwargs)
+        return super().max(*args, **kwargs)
 
     def min(self, *args, **kwargs):
         self.simplify()
-        return super(SimplifyHelperMixin, self).min(*args, **kwargs)
+        return super().min(*args, **kwargs)
 
     def eval(self, e, n, *args, **kwargs):
         if n > 1:
             self.simplify()
-        return super(SimplifyHelperMixin, self).eval(e, n, *args, **kwargs)
+        return super().eval(e, n, *args, **kwargs)
 
     def batch_eval(self, e, n, *args, **kwargs):
         if n > 1:
             self.simplify()
-        return super(SimplifyHelperMixin, self).batch_eval(e, n, *args, **kwargs)
+        return super().batch_eval(e, n, *args, **kwargs)

--- a/claripy/frontend_mixins/simplify_skipper_mixin.py
+++ b/claripy/frontend_mixins/simplify_skipper_mixin.py
@@ -1,14 +1,14 @@
 class SimplifySkipperMixin:
     def __init__(self, *args, **kwargs):
-        super(SimplifySkipperMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._simplified = True
 
     def _blank_copy(self, c):
-        super(SimplifySkipperMixin, self)._blank_copy(c)
+        super()._blank_copy(c)
         c._simplified = True
 
     def _copy(self, c):
-        super(SimplifySkipperMixin, self)._copy(c)
+        super()._copy(c)
         c._simplified = self._simplified
 
     def __getstate__(self):
@@ -23,7 +23,7 @@ class SimplifySkipperMixin:
     #
 
     def add(self, *args, **kwargs):
-        added = super(SimplifySkipperMixin, self).add(*args, **kwargs)
+        added = super().add(*args, **kwargs)
         if len(added) > 0:
             self._simplified = False
         return added
@@ -33,4 +33,4 @@ class SimplifySkipperMixin:
             return self.constraints
         else:
             self._simplified = True
-            return super(SimplifySkipperMixin, self).simplify(*args, **kwargs)
+            return super().simplify(*args, **kwargs)

--- a/claripy/frontend_mixins/solve_block_mixin.py
+++ b/claripy/frontend_mixins/solve_block_mixin.py
@@ -1,14 +1,14 @@
 class SolveBlockMixin:
     def __init__(self, *args, **kwargs):
-        super(SolveBlockMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.can_solve = True
 
     def _blank_copy(self, c):
-        super(SolveBlockMixin, self)._blank_copy(c)
+        super()._blank_copy(c)
         c.can_solve = True
 
     def _copy(self, c):
-        super(SolveBlockMixin, self)._copy(c)
+        super()._copy(c)
         c.can_solve = self.can_solve
 
     def __getstate__(self):
@@ -19,24 +19,24 @@ class SolveBlockMixin:
 
     def eval(self, *args, **kwargs):
         assert self.can_solve
-        return super(SolveBlockMixin, self).eval(*args, **kwargs)
+        return super().eval(*args, **kwargs)
 
     def batch_eval(self, *args, **kwargs):
         assert self.can_solve
-        return super(SolveBlockMixin, self).batch_eval(*args, **kwargs)
+        return super().batch_eval(*args, **kwargs)
 
     def min(self, *args, **kwargs):
         assert self.can_solve
-        return super(SolveBlockMixin, self).min(*args, **kwargs)
+        return super().min(*args, **kwargs)
 
     def max(self, *args, **kwargs):
         assert self.can_solve
-        return super(SolveBlockMixin, self).max(*args, **kwargs)
+        return super().max(*args, **kwargs)
 
     def satisfiable(self, *args, **kwargs):
         assert self.can_solve
-        return super(SolveBlockMixin, self).satisfiable(*args, **kwargs)
+        return super().satisfiable(*args, **kwargs)
 
     def solution(self, *args, **kwargs):
         assert self.can_solve
-        return super(SolveBlockMixin, self).solution(*args, **kwargs)
+        return super().solution(*args, **kwargs)

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -7,7 +7,7 @@ def op(name, arg_types, return_type, extra_check=None, calc_length=None, do_coer
     elif type(arg_types) is type: #pylint:disable=unidiomatic-typecheck
         expected_num_args = None
     else:
-        raise ClaripyOperationError("op {} got weird arg_types".format(name))
+        raise ClaripyOperationError(f"op {name} got weird arg_types")
 
     def _type_fixer(args):
         num_args = len(args)

--- a/claripy/smtlib_utils.py
+++ b/claripy/smtlib_utils.py
@@ -17,7 +17,7 @@ class SMTParser:
     def expect(self, *allowed):
         t = self.tokens.consume()
         if t not in allowed:
-            raise PysmtSyntaxError("Invalid token, expected any of {}, got '{}'".format(allowed, t))
+            raise PysmtSyntaxError(f"Invalid token, expected any of {allowed}, got '{t}'")
         return t
 
     def expect_assignment_tuple(self):

--- a/claripy/solvers.py
+++ b/claripy/solvers.py
@@ -16,7 +16,7 @@ class Solver(
     frontends.FullFrontend
 ):
     def __init__(self, backend=backends.z3, **kwargs):
-        super(Solver, self).__init__(backend, **kwargs)
+        super().__init__(backend, **kwargs)
 
 class SolverCacheless(
     frontend_mixins.ConstraintFixerMixin,
@@ -28,7 +28,7 @@ class SolverCacheless(
     frontends.FullFrontend
 ):
     def __init__(self, backend=backends.z3, **kwargs):
-        super(SolverCacheless, self).__init__(backend, **kwargs)
+        super().__init__(backend, **kwargs)
 
 class SolverReplacement(
     frontend_mixins.ConstraintFixerMixin,
@@ -38,7 +38,7 @@ class SolverReplacement(
 ):
     def __init__(self, actual_frontend=None, **kwargs):
         actual_frontend = Solver() if actual_frontend is None else actual_frontend
-        super(SolverReplacement, self).__init__(actual_frontend, **kwargs)
+        super().__init__(actual_frontend, **kwargs)
 
 class SolverHybrid(
     frontend_mixins.ConstraintFixerMixin,
@@ -61,7 +61,7 @@ class SolverHybrid(
             actual_frontend=SolverVSA(),
             complex_auto_replace=complex_auto_replace, replace_constraints=replace_constraints,
         ) if approximate_frontend is None else approximate_frontend
-        super(SolverHybrid, self).__init__(
+        super().__init__(
             exact_frontend, approximate_frontend, approximate_first=approximate_first, **kwargs
         )
 
@@ -72,7 +72,7 @@ class SolverVSA(
     frontends.LightFrontend
 ):
     def __init__(self, **kwargs):
-        super(SolverVSA, self).__init__(backends.vsa, **kwargs)
+        super().__init__(backends.vsa, **kwargs)
 
 class SolverConcrete(
     frontend_mixins.ConstraintFixerMixin,
@@ -81,7 +81,7 @@ class SolverConcrete(
     frontends.LightFrontend
 ):
     def __init__(self, **kwargs):
-        super(SolverConcrete, self).__init__(backends.concrete, **kwargs)
+        super().__init__(backends.concrete, **kwargs)
 
 class SolverStrings(
     # TODO: Figure ot if we need to use all these mixins
@@ -95,7 +95,7 @@ class SolverStrings(
     frontends.FullFrontend,
 ):
     def __init__(self, backend, *args, **kwargs):
-        super(SolverStrings, self).__init__(backend, *args, **kwargs)
+        super().__init__(backend, *args, **kwargs)
 
 #
 # Composite solving
@@ -109,7 +109,7 @@ class SolverCompositeChild(
     frontends.FullFrontend
 ):
     def __init__(self, backend=backends.z3, **kwargs):
-        super(SolverCompositeChild, self).__init__(backend, **kwargs)
+        super().__init__(backend, **kwargs)
 
     def __repr__(self):
         return "<SolverCompositeChild with %d variables>" % len(self.variables)
@@ -131,7 +131,7 @@ class SolverComposite(
         template_solver = SolverCompositeChild(track=track) if template_solver is None else template_solver
         template_solver_string = SolverCompositeChild(track=track, backend=backends.z3) if \
             template_solver_string is None else template_solver_string
-        super(SolverComposite, self).__init__(template_solver, template_solver_string, track=track, **kwargs)
+        super().__init__(template_solver, template_solver_string, track=track, **kwargs)
 
     def __repr__(self):
         return "<SolverComposite %x, %d children>" % (id(self), len(self._solver_list))

--- a/claripy/utils/orderedset.py
+++ b/claripy/utils/orderedset.py
@@ -55,8 +55,8 @@ class OrderedSet(collections.abc.MutableSet):
 
     def __repr__(self):
         if not self:
-            return '{}()'.format(self.__class__.__name__)
-        return '{}({!r})'.format(self.__class__.__name__, list(self))
+            return f'{self.__class__.__name__}()'
+        return f'{self.__class__.__name__}({list(self)!r})'
 
     def __eq__(self, other):
         if isinstance(other, OrderedSet):

--- a/claripy/utils/orderedset.py
+++ b/claripy/utils/orderedset.py
@@ -1,4 +1,3 @@
-
 import collections.abc
 
 
@@ -56,8 +55,8 @@ class OrderedSet(collections.abc.MutableSet):
 
     def __repr__(self):
         if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, list(self))
+            return '{}()'.format(self.__class__.__name__)
+        return '{}({!r})'.format(self.__class__.__name__, list(self))
 
     def __eq__(self, other):
         if isinstance(other, OrderedSet):

--- a/claripy/vsa/bool_result.py
+++ b/claripy/vsa/bool_result.py
@@ -199,7 +199,7 @@ class MaybeResult(BoolResult):
         if self._op is None:
             return '<Maybe>'
         else:
-            return '<Maybe({}, {})>'.format(self._op, self._args)
+            return f'<Maybe({self._op}, {self._args})>'
 
     def __bool__(self):
         return False

--- a/claripy/vsa/bool_result.py
+++ b/claripy/vsa/bool_result.py
@@ -199,7 +199,7 @@ class MaybeResult(BoolResult):
         if self._op is None:
             return '<Maybe>'
         else:
-            return '<Maybe(%s, %s)>' % (self._op, self._args)
+            return '<Maybe({}, {})>'.format(self._op, self._args)
 
     def __bool__(self):
         return False

--- a/claripy/vsa/errors.py
+++ b/claripy/vsa/errors.py
@@ -1,4 +1,3 @@
-
 from ..errors import ClaripyError
 
 class ClaripyVSAError(ClaripyError):

--- a/claripy/vsa/strided_interval.py
+++ b/claripy/vsa/strided_interval.py
@@ -464,7 +464,7 @@ class StridedInterval(BackendObject):
     #
 
     def __hash__(self):
-        return hash(('%x %x %x %x' % (self.bits, self.lower_bound, self.upper_bound, self.stride), self._reversed, self.uninitialized))
+        return hash(('{:x} {:x} {:x} {:x}'.format(self.bits, self.lower_bound, self.upper_bound, self.stride), self._reversed, self.uninitialized))
 
     def _normalize_top(self):
         if self.lower_bound == self._modular_add(self.upper_bound, 1, self.bits) and self.stride == 1:
@@ -1711,7 +1711,7 @@ class StridedInterval(BackendObject):
                 return StridedInterval.top(bits, uninitialized=uninit_flag)
 
         else:
-            raise Exception('We shouldn\'t see this case: %s * %s' % (a, b))
+            raise Exception('We shouldn\'t see this case: {} * {}'.format(a, b))
 
     @staticmethod
     def _wrapped_unsigned_div(a, b):

--- a/claripy/vsa/strided_interval.py
+++ b/claripy/vsa/strided_interval.py
@@ -464,7 +464,7 @@ class StridedInterval(BackendObject):
     #
 
     def __hash__(self):
-        return hash(('{:x} {:x} {:x} {:x}'.format(self.bits, self.lower_bound, self.upper_bound, self.stride), self._reversed, self.uninitialized))
+        return hash((f'{self.bits:x} {self.lower_bound:x} {self.upper_bound:x} {self.stride:x}', self._reversed, self.uninitialized))
 
     def _normalize_top(self):
         if self.lower_bound == self._modular_add(self.upper_bound, 1, self.bits) and self.stride == 1:
@@ -1711,7 +1711,7 @@ class StridedInterval(BackendObject):
                 return StridedInterval.top(bits, uninitialized=uninit_flag)
 
         else:
-            raise Exception('We shouldn\'t see this case: {} * {}'.format(a, b))
+            raise Exception(f'We shouldn\'t see this case: {a} * {b}')
 
     @staticmethod
     def _wrapped_unsigned_div(a, b):

--- a/claripy/vsa/valueset.py
+++ b/claripy/vsa/valueset.py
@@ -102,7 +102,7 @@ class RegionAnnotation(Annotation):
         return hash((self.region_id, self.region_base_addr, hash(self.offset)))
 
     def __repr__(self):
-        return "<RegionAnnotation {}:{:#08x}>".format(self.region_id, self.offset)
+        return f"<RegionAnnotation {self.region_id}:{self.offset:#08x}>"
 
 class ValueSet(BackendObject):
     """
@@ -282,7 +282,7 @@ class ValueSet(BackendObject):
     def __repr__(self):
         s = ""
         for region, si in self._regions.items():
-            s = "{}: {}".format(region, si)
+            s = f"{region}: {si}"
         return "(" + s + ")"
 
     def __len__(self):
@@ -601,7 +601,7 @@ class ValueSet(BackendObject):
                 new_vs._set_si(region, self._region_base_addrs[region], si.concat(b.get_si(region)))
 
         else:
-            raise ClaripyVSAOperationError('ValueSet.concat() got an unsupported operand {} (type {})'.format(b, type(b)))
+            raise ClaripyVSAOperationError(f'ValueSet.concat() got an unsupported operand {b} (type {type(b)})')
 
         return new_vs
 

--- a/claripy/vsa/valueset.py
+++ b/claripy/vsa/valueset.py
@@ -102,7 +102,7 @@ class RegionAnnotation(Annotation):
         return hash((self.region_id, self.region_base_addr, hash(self.offset)))
 
     def __repr__(self):
-        return "<RegionAnnotation %s:%#08x>" % (self.region_id, self.offset)
+        return "<RegionAnnotation {}:{:#08x}>".format(self.region_id, self.offset)
 
 class ValueSet(BackendObject):
     """
@@ -282,7 +282,7 @@ class ValueSet(BackendObject):
     def __repr__(self):
         s = ""
         for region, si in self._regions.items():
-            s = "%s: %s" % (region, si)
+            s = "{}: {}".format(region, si)
         return "(" + s + ")"
 
     def __len__(self):
@@ -601,7 +601,7 @@ class ValueSet(BackendObject):
                 new_vs._set_si(region, self._region_base_addrs[region], si.concat(b.get_si(region)))
 
         else:
-            raise ClaripyVSAOperationError('ValueSet.concat() got an unsupported operand %s (type %s)' % (b, type(b)))
+            raise ClaripyVSAOperationError('ValueSet.concat() got an unsupported operand {} (type {})'.format(b, type(b)))
 
         return new_vs
 

--- a/tests/test_backend_smt_congruency.py
+++ b/tests/test_backend_smt_congruency.py
@@ -48,7 +48,7 @@ class SmtLibSolverTestCongruency(unittest.TestCase):
             for var, val in model:
                 new = new.replace(var, val)
             self.assertTrue(new.is_true(),
-                            "Either model is incomplete or wrong! Constraint: {}, Model: {}".format(c, model))
+                            f"Either model is incomplete or wrong! Constraint: {c}, Model: {model}")
 
     def is_model_correct(self, csts, model):
         for c in csts:

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -80,7 +80,7 @@ def test_widened_guy():
     assert r[0][0] is w
     assert claripy.backends.vsa.min(r[0][1]) == 0
     all_vals = r[0][1]._model_vsa.eval(1000)
-    assert set(all_vals) == set([4294967295, 0, 1])
+    assert set(all_vals) == {4294967295, 0, 1}
 
 def test_overflow():
     x = claripy.BVS('x', 32)
@@ -90,7 +90,7 @@ def test_overflow():
     #mn,mx = claripy.backends.vsa.min(r[0][1]), claripy.backends.vsa.max(r[0][1])
     assert s
     assert r[0][0] is x
-    assert set(claripy.backends.vsa.eval(r[0][1], 1000)) == set([4294967286, 4294967287, 4294967288, 4294967289, 4294967290, 4294967291, 4294967292, 4294967293, 4294967294, 4294967295, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    assert set(claripy.backends.vsa.eval(r[0][1], 1000)) == {4294967286, 4294967287, 4294967288, 4294967289, 4294967290, 4294967291, 4294967292, 4294967293, 4294967294, 4294967295, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
     #print("0 <= x + 10")
     #s,r = claripy.balancer.Balancer(claripy.backends.vsa, 0 <= x + 10).compat_ret

--- a/tests/test_vsa.py
+++ b/tests/test_vsa.py
@@ -167,12 +167,12 @@ def test_wrapped_intervals():
     # Addition with overflowing cardinality
     si1 = claripy.SI(bits=8, stride=1, lower_bound=0, upper_bound=0xFE)
     si2 = claripy.SI(bits=8, stride=1, lower_bound=0xFE, upper_bound=0xFF)
-    assert vsa_model((si1 + si2)).is_top
+    assert vsa_model(si1 + si2).is_top
 
     # Addition that shouldn't get a TOP
     si1 = claripy.SI(bits=8, stride=1, lower_bound=0, upper_bound=0xFE)
     si2 = claripy.SI(bits=8, stride=1, lower_bound=0, upper_bound=0)
-    assert not vsa_model((si1 + si2)).is_top
+    assert not vsa_model(si1 + si2).is_top
 
     #
     # Subtraction


### PR DESCRIPTION
This applies a lot of overdue upgrades to claripy. The main 3 are:
1. python2 `super()` -> python3 `super()`
2. Prefer f-strings to `"a {1} b".format(c)` and `"a %s b" % (c,)`
3. `class ABC(object):` -> `class ABC:`

This was run with the flag: `--py38-plus`