### PR TITLE
Bump pysmt to stable version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 install_requires =
     cachetools
     decorator
-    pysmt>=0.9.1.dev119
+    pysmt>=0.9.5
     z3-solver==4.10.2.0
 python_requires = >=3.8
 


### PR DESCRIPTION
This bumps pysmt to be a stable version. Some tools like pipenv are weird when pinning dev versions.