### PR TITLE
Handle rare edge case where solver has 0 variables

### DIFF
--- a/claripy/frontends/composite_frontend.py
+++ b/claripy/frontends/composite_frontend.py
@@ -322,7 +322,7 @@ class CompositeFrontend(ConstrainedFrontend):
                 # skip solvers covered by extra constraints (they were checked above)
                 continue
 
-            if self._solvers[min(iter(s.variables))] is not s:
+            if len(s.variables) == 0 or self._solvers[min(iter(s.variables))] is not s:
                 # this happens when a parent solver didn't check all unchecked solvers, and we have stale
                 # child solvers in the unchecked list
                 continue


### PR DESCRIPTION
Under arcane circumstances I don't understand, this can happen. It didn't happen in a venv from a few days ago, but it happens now, despite using the same pinned commits of the angr repos. It also only happens with pypy and not CPython.