### PR TITLE
Fix incorrect merge in composite solver when child solvers are empty

### DIFF
--- a/claripy/frontends/composite_frontend.py
+++ b/claripy/frontends/composite_frontend.py
@@ -498,7 +498,8 @@ class CompositeFrontend(ConstrainedFrontend):
         for ns in noncommon_solvers:
             l.debug("... %d", len(ns))
             if len(ns) == 0:
-                pass
+                s = self._template_frontend.blank_copy()
+                combined_noncommons.append(s)
             elif len(ns) == 1:
                 combined_noncommons.append(ns[0])
             else:

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -117,6 +117,12 @@ class TestMerging(unittest.TestCase):
         smm_1.add(wxy != 0x000204)
         self.assertFalse(smm_1.satisfiable())
 
+        s3 = solver_type()
+        s3.add(w == 0)
+        s4 = solver_type()
+        _, sm = s3.merge([s4], [m == 0, m == 1])
+        self.assertEqual(len(sm.eval(w, 2)), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Simple example to reproduce:

```python
s1 = claripy.SolverComposite()
s2 = claripy.SolverComposite()
m = claripy.BVS("m", 8)
w = claripy.BVS("w", 8)
s1.add(w == 0)
_, sm = s1.merge([s2], [m == 0, m == 1])
sm.eval(w, 2) # returns (0,), despite w being unconstrained in s2
```

This can also be reproduced though some fairly trivial merges in angr:
```python
s1 = angr.SimState(arch='ARM', mode='symbolic')
x = s1.solver.BVS('x', 32)
s1.regs.r0 = x
s1.add_constraints(s1.regs.r0 == 42)

s2 = s1.copy()
y = s2.solver.BVS('y', 32)
s2.regs.r0 = y
s2.add_constraints(s2.regs.r0 == 43)

m, _, merged = s1.merge(s2)
print(m.solver.eval_upto(m.regs.r0, 10)) # prints [42], but it should be [42, 43]
```

I will admit I have not been working with claripy all that long, so let me know if there's something fundamental about this I'm misunderstanding. Thanks!