### PR TITLE
Update z3 to 4.12.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     cachetools
     decorator
     pysmt>=0.9.5
-    z3-solver==4.10.2.0
+    z3-solver==4.12.2.0
 python_requires = >=3.8
 
 [options.extras_require]


### PR DESCRIPTION
z3 finally released an update with my patch that fixes pyinstaller compatibility with newer versions. I'd like to sort out any compatibility issues and try to update.