### PR TITLE
Use a weak-value dict for _bvv_cache to avoid OOM.

### DIFF
--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -1,5 +1,6 @@
 import logging
 import numbers
+import weakref
 
 from .bits import Bits
 from ..ast.base import _make_name
@@ -8,7 +9,7 @@ from ..utils import deprecated
 
 l = logging.getLogger("claripy.ast.bv")
 
-_bvv_cache = {}
+_bvv_cache = weakref.WeakValueDictionary()
 
 
 # This is a hilarious hack to get around some sort of bug in z3's python bindings, where


### PR DESCRIPTION
I'm sure this PR slows down claripy (and angr) in cases where a huge number of duplicate BVVs are created during symbolic execution. But we can at least avoid OOM in some long-running symbolic execution cases.