### PR TITLE
Don't always nop out eager backends

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -211,8 +211,8 @@ class Base:
                 except BackendError:
                     eager_backends.remove(eb)
 
-        # if we can't be eager anymore, null out the eagerness
-        kwargs["eager_backends"] = None
+            # if we can't be eager anymore, null out the eagerness
+            kwargs["eager_backends"] = None
 
         # whether this guy is initialized or not
         if "uninitialized" not in kwargs:


### PR DESCRIPTION
I think there was a mistake in this commit: https://github.com/angr/claripy/commit/b6928e2164a5964f465961715880b9cf773bf9ea

Because of this mistake, eager_backends has always been set to None.