### PR TITLE
De-duplicate relocatable_annotations when creating AST

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -606,7 +606,9 @@ class Base:
             uneliminatable_annotations = frozenset(
                 anno for anno in annotations if not anno.eliminatable and not anno.relocatable
             )
-            relocatable_annotations = tuple(anno for anno in annotations if not anno.eliminatable and anno.relocatable)
+            relocatable_annotations = tuple(
+                frozenset(anno for anno in annotations if not anno.eliminatable and anno.relocatable)
+            )
 
             return type(self).__init_with_annotations__(
                 op,


### PR DESCRIPTION
I have a function where this makes the difference between the RDA finishing in ~3 seconds in comparison to it not finishing after 8 hours.

The `uneliminatable_annotations` are already deduplicated in the same way