### PR TITLE
Add clear_annotations to Base

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -739,6 +739,14 @@ class Base:
         """
         return self._apply_to_annotations(lambda alist: tuple(oa for oa in alist if oa not in remove_sequence))
 
+    def clear_annotations(self: T) -> T:
+        """
+        Removes all annotations from this AST.
+
+        :returns:                   a new AST, with all annotations removed
+        """
+        return self._apply_to_annotations(lambda _: ())
+
     #
     # Viewing and debugging
     #

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -139,6 +139,16 @@ def test_annotations():
     assert const2.depth == 3
 
 
+def test_clear_annotations():
+    x = claripy.BVS("x", 32).annotate(AnnotationA("a", 1))
+    y = x.clear_annotations()
+    assert len(y.annotations) == 0
+
+    x2 = claripy.BVS("x", 32).annotate(AnnotationA("a", 1)).annotate(AnnotationA("b", 2))
+    y2 = x2.clear_annotations()
+    assert len(y2.annotations) == 0
+
+
 def test_eagerness():
     x = claripy.BVV(10, 32).annotate(AnnotationD())
     y = x + 1


### PR DESCRIPTION
In #411 I changed the behavior of _apply_to_annotations. This broke the "clear annotations" use case that was used in angr. Rather than having an implicit use to handle this, let's add an api specifically for this. Any use of _apply_to_annotations outside of Base.py should be avoided.