### PR TITLE
Remove unused bound arg from op

### DIFF
--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -149,9 +149,9 @@ def If(*args):
         return ty("If", tuple(args))
 
 
-And = operations.op("And", Bool, Bool, bound=False)
-Or = operations.op("Or", Bool, Bool, bound=False)
-Not = operations.op("Not", (Bool,), Bool, bound=False)
+And = operations.op("And", Bool, Bool)
+Or = operations.op("Or", Bool, Bool)
+Not = operations.op("Not", (Bool,), Bool)
 
 Bool.__invert__ = Not
 Bool.__and__ = And

--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -413,14 +413,14 @@ def DSIS(
 
 
 # comparisons
-ULT = operations.op("__lt__", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
-ULE = operations.op("__le__", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
-UGT = operations.op("__gt__", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
-UGE = operations.op("__ge__", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
-SLT = operations.op("SLT", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
-SLE = operations.op("SLE", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
-SGT = operations.op("SGT", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
-SGE = operations.op("SGE", (BV, BV), Bool, extra_check=operations.length_same_check, bound=False)
+ULT = operations.op("__lt__", (BV, BV), Bool, extra_check=operations.length_same_check)
+ULE = operations.op("__le__", (BV, BV), Bool, extra_check=operations.length_same_check)
+UGT = operations.op("__gt__", (BV, BV), Bool, extra_check=operations.length_same_check)
+UGE = operations.op("__ge__", (BV, BV), Bool, extra_check=operations.length_same_check)
+SLT = operations.op("SLT", (BV, BV), Bool, extra_check=operations.length_same_check)
+SLE = operations.op("SLE", (BV, BV), Bool, extra_check=operations.length_same_check)
+SGT = operations.op("SGT", (BV, BV), Bool, extra_check=operations.length_same_check)
+SGE = operations.op("SGE", (BV, BV), Bool, extra_check=operations.length_same_check)
 
 # division
 SDiv = operations.op(
@@ -428,7 +428,6 @@ SDiv = operations.op(
     (BV, BV),
     BV,
     extra_check=operations.length_same_check,
-    bound=False,
     calc_length=operations.basic_length_calc,
 )
 SMod = operations.op(
@@ -436,7 +435,6 @@ SMod = operations.op(
     (BV, BV),
     BV,
     extra_check=operations.length_same_check,
-    bound=False,
     calc_length=operations.basic_length_calc,
 )
 
@@ -447,13 +445,12 @@ LShR = operations.op(
     BV,
     extra_check=operations.length_same_check,
     calc_length=operations.basic_length_calc,
-    bound=False,
 )
 SignExt = operations.op(
-    "SignExt", (int, BV), BV, extra_check=operations.extend_check, calc_length=operations.ext_length_calc, bound=False
+    "SignExt", (int, BV), BV, extra_check=operations.extend_check, calc_length=operations.ext_length_calc
 )
 ZeroExt = operations.op(
-    "ZeroExt", (int, BV), BV, extra_check=operations.extend_check, calc_length=operations.ext_length_calc, bound=False
+    "ZeroExt", (int, BV), BV, extra_check=operations.extend_check, calc_length=operations.ext_length_calc
 )
 Extract = operations.op(
     "Extract",
@@ -461,10 +458,9 @@ Extract = operations.op(
     BV,
     extra_check=operations.extract_check,
     calc_length=operations.extract_length_calc,
-    bound=False,
 )
 
-Concat = operations.op("Concat", BV, BV, calc_length=operations.concat_length_calc, bound=False)
+Concat = operations.op("Concat", BV, BV, calc_length=operations.concat_length_calc)
 
 RotateLeft = operations.op(
     "RotateLeft",
@@ -472,7 +468,6 @@ RotateLeft = operations.op(
     BV,
     extra_check=operations.length_same_check,
     calc_length=operations.basic_length_calc,
-    bound=False,
 )
 RotateRight = operations.op(
     "RotateRight",
@@ -480,9 +475,8 @@ RotateRight = operations.op(
     BV,
     extra_check=operations.length_same_check,
     calc_length=operations.basic_length_calc,
-    bound=False,
 )
-Reverse = operations.op("Reverse", (BV,), BV, calc_length=operations.basic_length_calc, bound=False)
+Reverse = operations.op("Reverse", (BV,), BV, calc_length=operations.basic_length_calc)
 
 union = operations.op(
     "union",
@@ -490,7 +484,6 @@ union = operations.op(
     BV,
     extra_check=operations.length_same_check,
     calc_length=operations.basic_length_calc,
-    bound=False,
 )
 widen = operations.op(
     "widen",
@@ -498,7 +491,6 @@ widen = operations.op(
     BV,
     extra_check=operations.length_same_check,
     calc_length=operations.basic_length_calc,
-    bound=False,
 )
 intersection = operations.op(
     "intersection",
@@ -506,7 +498,6 @@ intersection = operations.op(
     BV,
     extra_check=operations.length_same_check,
     calc_length=operations.basic_length_calc,
-    bound=False,
 )
 
 #
@@ -544,7 +535,6 @@ BV.SDiv = operations.op(
     (BV, BV),
     BV,
     extra_check=operations.length_same_check,
-    bound=False,
     calc_length=operations.basic_length_calc,
 )
 BV.SMod = operations.op(
@@ -552,7 +542,6 @@ BV.SMod = operations.op(
     (BV, BV),
     BV,
     extra_check=operations.length_same_check,
-    bound=False,
     calc_length=operations.basic_length_calc,
 )
 
@@ -607,10 +596,9 @@ BV.Extract = staticmethod(
         BV,
         extra_check=operations.extract_check,
         calc_length=operations.extract_length_calc,
-        bound=False,
     )
 )
-BV.Concat = staticmethod(operations.op("Concat", BV, BV, calc_length=operations.concat_length_calc, bound=False))
+BV.Concat = staticmethod(operations.op("Concat", BV, BV, calc_length=operations.concat_length_calc))
 BV.reversed = property(operations.op("Reverse", (BV,), BV, calc_length=operations.basic_length_calc))
 
 BV.union = operations.op(

--- a/claripy/ast/fp.py
+++ b/claripy/ast/fp.py
@@ -132,12 +132,12 @@ def _fp_length_calc(a1, a2, a3=None):
         return a3.length
 
 
-fpToFP = operations.op("fpToFP", object, FP, bound=False, calc_length=_fp_length_calc)
-fpToFPUnsigned = operations.op("fpToFPUnsigned", (fp.RM, BV, fp.FSort), FP, bound=False, calc_length=_fp_length_calc)
-fpFP = operations.op("fpFP", (BV, BV, BV), FP, bound=False, calc_length=lambda a, b, c: a.length + b.length + c.length)
-fpToIEEEBV = operations.op("fpToIEEEBV", (FP,), BV, bound=False, calc_length=lambda fp: fp.length)
-fpToSBV = operations.op("fpToSBV", (fp.RM, FP, int), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
-fpToUBV = operations.op("fpToUBV", (fp.RM, FP, int), BV, bound=False, calc_length=lambda _rm, _fp, len: len)
+fpToFP = operations.op("fpToFP", object, FP, calc_length=_fp_length_calc)
+fpToFPUnsigned = operations.op("fpToFPUnsigned", (fp.RM, BV, fp.FSort), FP, calc_length=_fp_length_calc)
+fpFP = operations.op("fpFP", (BV, BV, BV), FP, calc_length=lambda a, b, c: a.length + b.length + c.length)
+fpToIEEEBV = operations.op("fpToIEEEBV", (FP,), BV, calc_length=lambda fp: fp.length)
+fpToSBV = operations.op("fpToSBV", (fp.RM, FP, int), BV, calc_length=lambda _rm, _fp, len: len)
+fpToUBV = operations.op("fpToUBV", (fp.RM, FP, int), BV, calc_length=lambda _rm, _fp, len: len)
 
 #
 # unbound float point comparisons
@@ -148,13 +148,13 @@ def _fp_cmp_check(a, b):
     return a.length == b.length, "FP lengths must be the same"
 
 
-fpEQ = operations.op("fpEQ", (FP, FP), Bool, bound=False, extra_check=_fp_cmp_check)
-fpGT = operations.op("fpGT", (FP, FP), Bool, bound=False, extra_check=_fp_cmp_check)
-fpGEQ = operations.op("fpGEQ", (FP, FP), Bool, bound=False, extra_check=_fp_cmp_check)
-fpLT = operations.op("fpLT", (FP, FP), Bool, bound=False, extra_check=_fp_cmp_check)
-fpLEQ = operations.op("fpLEQ", (FP, FP), Bool, bound=False, extra_check=_fp_cmp_check)
-fpIsNaN = operations.op("fpIsNaN", (FP,), Bool, bound=False)
-fpIsInf = operations.op("fpIsInf", (FP,), Bool, bound=False)
+fpEQ = operations.op("fpEQ", (FP, FP), Bool, extra_check=_fp_cmp_check)
+fpGT = operations.op("fpGT", (FP, FP), Bool, extra_check=_fp_cmp_check)
+fpGEQ = operations.op("fpGEQ", (FP, FP), Bool, extra_check=_fp_cmp_check)
+fpLT = operations.op("fpLT", (FP, FP), Bool, extra_check=_fp_cmp_check)
+fpLEQ = operations.op("fpLEQ", (FP, FP), Bool, extra_check=_fp_cmp_check)
+fpIsNaN = operations.op("fpIsNaN", (FP,), Bool)
+fpIsInf = operations.op("fpIsInf", (FP,), Bool)
 
 #
 # unbound floating point arithmetic
@@ -169,20 +169,12 @@ def _fp_binop_length(rm, a, b):  # pylint:disable=unused-argument
     return a.length
 
 
-fpAbs = operations.op("fpAbs", (FP,), FP, bound=False, calc_length=lambda x: x.length)
-fpNeg = operations.op("fpNeg", (FP,), FP, bound=False, calc_length=lambda x: x.length)
-fpSub = operations.op(
-    "fpSub", (fp.RM, FP, FP), FP, bound=False, extra_check=_fp_binop_check, calc_length=_fp_binop_length
-)
-fpAdd = operations.op(
-    "fpAdd", (fp.RM, FP, FP), FP, bound=False, extra_check=_fp_binop_check, calc_length=_fp_binop_length
-)
-fpMul = operations.op(
-    "fpMul", (fp.RM, FP, FP), FP, bound=False, extra_check=_fp_binop_check, calc_length=_fp_binop_length
-)
-fpDiv = operations.op(
-    "fpDiv", (fp.RM, FP, FP), FP, bound=False, extra_check=_fp_binop_check, calc_length=_fp_binop_length
-)
+fpAbs = operations.op("fpAbs", (FP,), FP, calc_length=lambda x: x.length)
+fpNeg = operations.op("fpNeg", (FP,), FP, calc_length=lambda x: x.length)
+fpSub = operations.op("fpSub", (fp.RM, FP, FP), FP, extra_check=_fp_binop_check, calc_length=_fp_binop_length)
+fpAdd = operations.op("fpAdd", (fp.RM, FP, FP), FP, extra_check=_fp_binop_check, calc_length=_fp_binop_length)
+fpMul = operations.op("fpMul", (fp.RM, FP, FP), FP, extra_check=_fp_binop_check, calc_length=_fp_binop_length)
+fpDiv = operations.op("fpDiv", (fp.RM, FP, FP), FP, extra_check=_fp_binop_check, calc_length=_fp_binop_length)
 fpSqrt = operations.op(
     "fpSqrt",
     (
@@ -190,7 +182,6 @@ fpSqrt = operations.op(
         FP,
     ),
     FP,
-    bound=False,
     calc_length=lambda _, x: x.length,
 )
 

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -168,26 +168,23 @@ def StringV(value, length: int | None = None, **kwargs):
     return result
 
 
-StrConcat = operations.op("StrConcat", String, String, calc_length=operations.str_concat_length_calc, bound=False)
-StrSubstr = operations.op("StrSubstr", (BV, BV, String), String, calc_length=operations.substr_length_calc, bound=False)
-StrLen = operations.op("StrLen", (String, int), BV, calc_length=operations.strlen_bv_size_calc, bound=False)
+StrConcat = operations.op("StrConcat", String, String, calc_length=operations.str_concat_length_calc)
+StrSubstr = operations.op("StrSubstr", (BV, BV, String), String, calc_length=operations.substr_length_calc)
+StrLen = operations.op("StrLen", (String, int), BV, calc_length=operations.strlen_bv_size_calc)
 StrReplace = operations.op(
     "StrReplace",
     (String, String, String),
     String,
     extra_check=operations.str_replace_check,
     calc_length=operations.str_replace_length_calc,
-    bound=False,
 )
-StrContains = operations.op("StrContains", (String, String), Bool, bound=False)
-StrPrefixOf = operations.op("StrPrefixOf", (String, String), Bool, bound=False)
-StrSuffixOf = operations.op("StrSuffixOf", (String, String), Bool, bound=False)
-StrIndexOf = operations.op(
-    "StrIndexOf", (String, String, BV, int), BV, calc_length=operations.strindexof_bv_size_calc, bound=False
-)
-StrToInt = operations.op("StrToInt", (String, int), BV, calc_length=operations.strtoint_bv_size_calc, bound=False)
-IntToStr = operations.op("IntToStr", (BV,), String, calc_length=operations.int_to_str_length_calc, bound=False)
-StrIsDigit = operations.op("StrIsDigit", (String,), Bool, bound=False)
+StrContains = operations.op("StrContains", (String, String), Bool)
+StrPrefixOf = operations.op("StrPrefixOf", (String, String), Bool)
+StrSuffixOf = operations.op("StrSuffixOf", (String, String), Bool)
+StrIndexOf = operations.op("StrIndexOf", (String, String, BV, int), BV, calc_length=operations.strindexof_bv_size_calc)
+StrToInt = operations.op("StrToInt", (String, int), BV, calc_length=operations.strtoint_bv_size_calc)
+IntToStr = operations.op("IntToStr", (BV,), String, calc_length=operations.int_to_str_length_calc)
+StrIsDigit = operations.op("StrIsDigit", (String,), Bool)
 
 # Equality / inequality check
 String.__eq__ = operations.op("__eq__", (String, String), Bool)

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -5,9 +5,7 @@ from . import debug as _d
 from .errors import ClaripyOperationError, ClaripyTypeError
 
 
-def op(
-    name, arg_types, return_type, extra_check=None, calc_length=None, do_coerce=True, bound=True
-):  # pylint:disable=unused-argument
+def op(name, arg_types, return_type, extra_check=None, calc_length=None, do_coerce=True):
     if type(arg_types) in (tuple, list):  # pylint:disable=unidiomatic-typecheck
         expected_num_args = len(arg_types)
     elif type(arg_types) is type:  # pylint:disable=unidiomatic-typecheck


### PR DESCRIPTION
Doesn't appear to ever have been used, even in the commit it was added in. The parameter is set many times, but never used.