### PR TITLE
Dekwargsify frontend

### DIFF
--- a/claripy/frontend.py
+++ b/claripy/frontend.py
@@ -62,7 +62,7 @@ class Frontend:
     def split(self):
         raise NotImplementedError("split() is not implemented")
 
-    def add(self, constraints):
+    def add(self, constraints, invalidate_cache=True):
         """
         Adds constraint(s) to constraints list.
 
@@ -220,7 +220,8 @@ class Frontend:
         else:
             return None
 
-    _concrete_constraint = _concrete_value
+    def _concrete_constraint(self, e):  # pylint:disable=no-self-use
+        return self._concrete_value(e)
 
     def _constraint_filter(self, c):  # pylint:disable=no-self-use
         return c

--- a/claripy/frontend_mixins/composited_cache_mixin.py
+++ b/claripy/frontend_mixins/composited_cache_mixin.py
@@ -50,6 +50,6 @@ class CompositedCacheMixin:
         super().downsize()
         self._merged_solvers = {}
 
-    def _store_child(self, s, **kwargs):
-        self._remove_cached(s.variables)
-        return super()._store_child(s, **kwargs)
+    def _store_child(self, ns, extra_names=frozenset(), invalidate_cache=True):
+        self._remove_cached(ns.variables)
+        return super()._store_child(ns, extra_names=extra_names, invalidate_cache=invalidate_cache)

--- a/claripy/frontend_mixins/concrete_handler_mixin.py
+++ b/claripy/frontend_mixins/concrete_handler_mixin.py
@@ -1,54 +1,56 @@
 class ConcreteHandlerMixin:
-    def eval(self, e, n, **kwargs):  # pylint:disable=unused-argument
+    def eval(self, e, n, extra_constraints=(), exact=None):
         c = self._concrete_value(e)
         if c is not None:
             return (c,)
         else:
-            return super().eval(e, n, **kwargs)
+            return super().eval(e, n, extra_constraints=extra_constraints, exact=exact)
 
-    def batch_eval(self, exprs, n, **kwargs):  # pylint:disable=unused-argument
+    def batch_eval(self, exprs, n, extra_constraints=(), exact=None):
         concrete_exprs = [self._concrete_value(e) for e in exprs]
         symbolic_exprs = [e for e, c in zip(exprs, concrete_exprs) if c is None]
 
         if len(symbolic_exprs) == 0:
             return [concrete_exprs]
 
-        symbolic_results = map(list, super().batch_eval(symbolic_exprs, n, **kwargs))
+        symbolic_results = map(
+            list, super().batch_eval(symbolic_exprs, n, extra_constraints=extra_constraints, exact=exact)
+        )
         return [tuple((c if c is not None else r.pop(0)) for c in concrete_exprs) for r in symbolic_results]
 
-    def max(self, e, **kwargs):
+    def max(self, e, extra_constraints=(), signed=False, exact=None):
         c = self._concrete_value(e)
         if c is not None:
             return c
         else:
-            return super().max(e, **kwargs)
+            return super().max(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
 
-    def min(self, e, **kwargs):
+    def min(self, e, extra_constraints=(), signed=False, exact=None):
         c = self._concrete_value(e)
         if c is not None:
             return c
         else:
-            return super().min(e, **kwargs)
+            return super().min(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
 
-    def solution(self, e, v, **kwargs):
+    def solution(self, e, v, extra_constraints=(), exact=None):
         ce = self._concrete_value(e)
         cv = self._concrete_value(v)
 
         if ce is None or cv is None:
-            return super().solution(e, v, **kwargs)
+            return super().solution(e, v, extra_constraints=extra_constraints, exact=exact)
         else:
             return ce == cv
 
-    def is_true(self, e, **kwargs):
+    def is_true(self, e, extra_constraints=(), exact=None):
         c = self._concrete_value(e)
         if c is not None:
             return c
         else:
-            return super().is_true(e, **kwargs)
+            return super().is_true(e, extra_constraints=extra_constraints, exact=exact)
 
-    def is_false(self, e, **kwargs):
+    def is_false(self, e, extra_constraints=(), exact=None):
         c = self._concrete_value(e)
         if c is not None:
             return not c
         else:
-            return super().is_false(e, **kwargs)
+            return super().is_false(e, extra_constraints=extra_constraints, exact=exact)

--- a/claripy/frontend_mixins/constraint_deduplicator_mixin.py
+++ b/claripy/frontend_mixins/constraint_deduplicator_mixin.py
@@ -18,19 +18,19 @@ class ConstraintDeduplicatorMixin:
         self._constraint_hashes, base_state = s
         super().__setstate__(base_state)
 
-    def simplify(self, **kwargs):
-        added = super().simplify(**kwargs)
+    def simplify(self):
+        added = super().simplify()
         # we only add to the constraint hashes because we want to
         # prevent previous (now simplified) constraints from
         # being re-added
         self._constraint_hashes.update(map(hash, added))
         return added
 
-    def add(self, constraints, **kwargs):
+    def add(self, constraints, invalidate_cache=True):
         filtered = tuple(c for c in constraints if hash(c) not in self._constraint_hashes)
         if len(filtered) == 0:
             return filtered
 
-        added = super().add(filtered, **kwargs)
+        added = super().add(filtered, invalidate_cache=invalidate_cache)
         self._constraint_hashes.update(map(hash, added))
         return added

--- a/claripy/frontend_mixins/constraint_expansion_mixin.py
+++ b/claripy/frontend_mixins/constraint_expansion_mixin.py
@@ -7,8 +7,8 @@ l = logging.getLogger("claripy.frontends.cache_mixin")
 
 
 class ConstraintExpansionMixin:
-    def eval(self, e, n, extra_constraints=(), exact=None, **kwargs):
-        results = super().eval(e, n, extra_constraints=extra_constraints, exact=exact, **kwargs)
+    def eval(self, e, n, extra_constraints=(), exact=None):
+        results = super().eval(e, n, extra_constraints=extra_constraints, exact=exact)
 
         # if there are less possible solutions than n (i.e., meaning we got all the solutions for e),
         # add constraints to help the solver out later
@@ -18,20 +18,20 @@ class ConstraintExpansionMixin:
 
         return results
 
-    def max(self, e, extra_constraints=(), exact=None, signed=False, **kwargs):
-        m = super().max(e, extra_constraints=extra_constraints, exact=exact, signed=signed, **kwargs)
+    def max(self, e, extra_constraints=(), signed=False, exact=None):
+        m = super().max(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
         if len(extra_constraints) == 0:
             self.add([SLE(e, m) if signed else ULE(e, m)], invalidate_cache=False)
         return m
 
-    def min(self, e, extra_constraints=(), exact=None, signed=False, **kwargs):
-        m = super().min(e, extra_constraints=extra_constraints, exact=exact, signed=signed, **kwargs)
+    def min(self, e, extra_constraints=(), signed=False, exact=None):
+        m = super().min(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
         if len(extra_constraints) == 0:
             self.add([SGE(e, m) if signed else UGE(e, m)], invalidate_cache=False)
         return m
 
-    def solution(self, e, v, extra_constraints=(), exact=None, **kwargs):
-        b = super().solution(e, v, extra_constraints=extra_constraints, exact=exact, **kwargs)
+    def solution(self, e, v, extra_constraints=(), exact=None):
+        b = super().solution(e, v, extra_constraints=extra_constraints, exact=exact)
         if b is False and len(extra_constraints) == 0:
             self.add([e != v], invalidate_cache=False)
         return b

--- a/claripy/frontend_mixins/constraint_filter_mixin.py
+++ b/claripy/frontend_mixins/constraint_filter_mixin.py
@@ -3,21 +3,21 @@ from claripy.errors import ClaripyValueError, UnsatError
 
 
 class ConstraintFilterMixin:
-    def _constraint_filter(self, constraints, **kwargs):
+    def _constraint_filter(self, constraints):
         if type(constraints) not in (tuple, list):
             raise ClaripyValueError("The extra_constraints argument should be a list of constraints.")
 
         if len(constraints) == 0:
             return constraints
 
-        filtered = super()._constraint_filter(constraints, **kwargs)
+        filtered = super()._constraint_filter(constraints)
         ccs = [self._concrete_constraint(c) for c in filtered]
         if False in ccs:
             raise UnsatError("Constraints contain False.")
         else:
             return tuple((o if n is None else o) for o, n in zip(constraints, ccs) if n is not True)
 
-    def add(self, constraints, **kwargs):
+    def add(self, constraints, invalidate_cache=True):
         try:
             ec = self._constraint_filter(constraints)
         except UnsatError:
@@ -28,41 +28,41 @@ class ConstraintFilterMixin:
             return []
 
         if len(ec) > 0:
-            return super().add(ec, **kwargs)
+            return super().add(ec, invalidate_cache=invalidate_cache)
         else:
             return []
 
-    def satisfiable(self, extra_constraints=(), **kwargs):
+    def satisfiable(self, extra_constraints=(), exact=None):
         try:
             ec = self._constraint_filter(extra_constraints)
-            return super().satisfiable(extra_constraints=ec, **kwargs)
+            return super().satisfiable(extra_constraints=ec, exact=exact)
         except UnsatError:
             return False
 
-    def eval(self, e, n, extra_constraints=(), **kwargs):
+    def eval(self, e, n, extra_constraints=(), exact=None):
         ec = self._constraint_filter(extra_constraints)
-        return super().eval(e, n, extra_constraints=ec, **kwargs)
+        return super().eval(e, n, extra_constraints=ec, exact=exact)
 
-    def batch_eval(self, exprs, n, extra_constraints=(), **kwargs):
+    def batch_eval(self, exprs, n, extra_constraints=(), exact=None):
         ec = self._constraint_filter(extra_constraints)
-        return super().batch_eval(exprs, n, extra_constraints=ec, **kwargs)
+        return super().batch_eval(exprs, n, extra_constraints=ec, exact=exact)
 
-    def max(self, e, extra_constraints=(), **kwargs):
+    def max(self, e, extra_constraints=(), signed=False, exact=None):
         ec = self._constraint_filter(extra_constraints)
-        return super().max(e, extra_constraints=ec, **kwargs)
+        return super().max(e, extra_constraints=ec, signed=signed, exact=exact)
 
-    def min(self, e, extra_constraints=(), **kwargs):
+    def min(self, e, extra_constraints=(), signed=False, exact=None):
         ec = self._constraint_filter(extra_constraints)
-        return super().min(e, extra_constraints=ec, **kwargs)
+        return super().min(e, extra_constraints=ec, signed=signed, exact=exact)
 
-    def solution(self, e, v, extra_constraints=(), **kwargs):
+    def solution(self, e, v, extra_constraints=(), exact=None):
         ec = self._constraint_filter(extra_constraints)
-        return super().solution(e, v, extra_constraints=ec, **kwargs)
+        return super().solution(e, v, extra_constraints=ec, exact=exact)
 
-    def is_true(self, e, extra_constraints=(), **kwargs):
+    def is_true(self, e, extra_constraints=(), exact=None):
         ec = self._constraint_filter(extra_constraints)
-        return super().is_true(e, extra_constraints=ec, **kwargs)
+        return super().is_true(e, extra_constraints=ec, exact=exact)
 
-    def is_false(self, e, extra_constraints=(), **kwargs):
+    def is_false(self, e, extra_constraints=(), exact=None):
         ec = self._constraint_filter(extra_constraints)
-        return super().is_false(e, extra_constraints=ec, **kwargs)
+        return super().is_false(e, extra_constraints=ec, exact=exact)

--- a/claripy/frontend_mixins/constraint_fixer_mixin.py
+++ b/claripy/frontend_mixins/constraint_fixer_mixin.py
@@ -1,17 +1,12 @@
-from typing import TYPE_CHECKING, Union
-
 from claripy import BoolV
-
-if TYPE_CHECKING:
-    from claripy.ast.bool import Bool
 
 
 class ConstraintFixerMixin:
-    def add(self, constraints: Union["Bool", list["Bool"], set["Bool"], tuple["Bool", ...]], **kwargs) -> list["Bool"]:
+    def add(self, constraints, invalidate_cache=True):
         constraints = [constraints] if not isinstance(constraints, list | tuple | set) else constraints
 
         if len(constraints) == 0:
             return []
 
         constraints = [BoolV(c) if isinstance(c, bool) else c for c in constraints]
-        return super().add(constraints, **kwargs)
+        return super().add(constraints, invalidate_cache=invalidate_cache)

--- a/claripy/frontend_mixins/constraint_fixer_mixin.py
+++ b/claripy/frontend_mixins/constraint_fixer_mixin.py
@@ -2,6 +2,10 @@ from claripy import BoolV
 
 
 class ConstraintFixerMixin:
+    """ConstraintFixerMixin is a mixin that overrides add() to support various
+    unexpected inputs. It converts various inputs to a list of BoolV objects.
+    """
+
     def add(self, constraints, invalidate_cache=True):
         constraints = [constraints] if not isinstance(constraints, list | tuple | set) else constraints
 

--- a/claripy/frontend_mixins/eager_resolution_mixin.py
+++ b/claripy/frontend_mixins/eager_resolution_mixin.py
@@ -3,6 +3,9 @@ from claripy.errors import BackendError
 
 
 class EagerResolutionMixin:
+    """EagerResolutionMixin is a mixin that overrides _concrete_value to add
+    eager evaluation."""
+
     def _concrete_value(self, e):
         r = super()._concrete_value(e)
         if r is not None:

--- a/claripy/frontend_mixins/eager_resolution_mixin.py
+++ b/claripy/frontend_mixins/eager_resolution_mixin.py
@@ -15,5 +15,3 @@ class EagerResolutionMixin:
                 pass
 
         return None
-
-    _concrete_constraint = _concrete_value

--- a/claripy/frontend_mixins/model_cache_mixin.py
+++ b/claripy/frontend_mixins/model_cache_mixin.py
@@ -160,8 +160,8 @@ class ModelCacheMixin:
     # Model cleaning
     #
 
-    def simplify(self, *args, **kwargs):
-        results = super().simplify(*args, **kwargs)
+    def simplify(self):
+        results = super().simplify()
         if len(results) > 0 and any(c is false for c in results):
             self._models.clear()
         return results
@@ -185,12 +185,12 @@ class ModelCacheMixin:
         self._max_signed_exhausted.add(c.args[0].cache_key)
         self._min_signed_exhausted.add(c.args[0].cache_key)
 
-    def add(self, constraints, invalidate_cache=True, **kwargs):
+    def add(self, constraints, invalidate_cache=True):
         if len(constraints) == 0:
             return constraints
 
         old_vars = frozenset(self.variables)
-        added = super().add(constraints, **kwargs)
+        added = super().add(constraints, invalidate_cache=invalidate_cache)
         if len(added) == 0:
             return added
 
@@ -300,12 +300,12 @@ class ModelCacheMixin:
     # Cached functions
     #
 
-    def satisfiable(self, extra_constraints=(), **kwargs):
+    def satisfiable(self, extra_constraints=(), exact=None):
         for _ in self._get_models(extra_constraints=extra_constraints):
             return True
-        return super().satisfiable(extra_constraints=extra_constraints, **kwargs)
+        return super().satisfiable(extra_constraints=extra_constraints, exact=exact)
 
-    def batch_eval(self, asts, n, extra_constraints=(), **kwargs):
+    def batch_eval(self, asts, n, extra_constraints=(), exact=None):
         results = self._get_batch_solutions(asts, n=n, extra_constraints=extra_constraints)
 
         if len(results) == n or (len(asts) == 1 and asts[0].cache_key in self._eval_exhausted):
@@ -323,7 +323,7 @@ class ModelCacheMixin:
             constraints = extra_constraints
 
         try:
-            results.update(super().batch_eval(asts, remaining, extra_constraints=constraints, **kwargs))
+            results.update(super().batch_eval(asts, remaining, extra_constraints=constraints, exact=exact))
         except UnsatError:
             if len(results) == 0:
                 raise
@@ -337,10 +337,12 @@ class ModelCacheMixin:
 
         return results
 
-    def eval(self, e, n, **kwargs):
-        return tuple(r[0] for r in ModelCacheMixin.batch_eval(self, [e], n=n, **kwargs))
+    def eval(self, e, n, extra_constraints=(), exact=None):
+        return tuple(
+            r[0] for r in ModelCacheMixin.batch_eval(self, [e], n, extra_constraints=extra_constraints, exact=exact)
+        )
 
-    def min(self, e, extra_constraints=(), signed=False, **kwargs):
+    def min(self, e, extra_constraints=(), signed=False, exact=None):
         cached = []
         if e.cache_key in self._eval_exhausted or e.cache_key in self._min_exhausted:
             # we set allow_unconstrained to False because we expect all returned values for e are returned by Z3,
@@ -351,12 +353,12 @@ class ModelCacheMixin:
             signed_key = lambda v: v if v < 2 ** (len(e) - 1) else v - 2 ** len(e)
             return min(cached, key=signed_key if signed else lambda v: v)
         else:
-            m = super().min(e, extra_constraints=extra_constraints, signed=signed, **kwargs)
+            m = super().min(e, extra_constraints=extra_constraints, signed=signed, exact=None)
             if len(extra_constraints) == 0:
                 (self._min_signed_exhausted if signed else self._min_exhausted).add(e.cache_key)
             return m
 
-    def max(self, e, extra_constraints=(), signed=False, **kwargs):
+    def max(self, e, extra_constraints=(), signed=False, exact=None):
         cached = []
         if e.cache_key in self._eval_exhausted or e.cache_key in self._max_exhausted:
             cached = self._get_solutions(e, extra_constraints=extra_constraints, allow_unconstrained=False)
@@ -365,12 +367,12 @@ class ModelCacheMixin:
             signed_key = lambda v: v if v < 2 ** (len(e) - 1) else v - 2 ** len(e)
             return max(cached, key=signed_key if signed else lambda v: v)
         else:
-            m = super().max(e, extra_constraints=extra_constraints, signed=signed, **kwargs)
+            m = super().max(e, extra_constraints=extra_constraints, signed=signed, exact=None)
             if len(extra_constraints) == 0:
                 (self._max_signed_exhausted if signed else self._max_exhausted).add(e.cache_key)
             return m
 
-    def solution(self, e, v, extra_constraints=(), **kwargs):
+    def solution(self, e, v, extra_constraints=(), exact=None):
         if isinstance(v, Base):
             cached = self._get_batch_solutions([e, v], extra_constraints=extra_constraints)
             if any(ec == vc for ec, vc in cached):
@@ -380,4 +382,4 @@ class ModelCacheMixin:
             if v in cached:
                 return True
 
-        return super().solution(e, v, extra_constraints=extra_constraints, **kwargs)
+        return super().solution(e, v, extra_constraints=extra_constraints, exact=None)

--- a/claripy/frontend_mixins/sat_cache_mixin.py
+++ b/claripy/frontend_mixins/sat_cache_mixin.py
@@ -26,8 +26,8 @@ class SatCacheMixin:
     # SAT caching
     #
 
-    def add(self, constraints, **kwargs):
-        added = super().add(constraints, **kwargs)
+    def add(self, constraints, invalidate_cache=True):
+        added = super().add(constraints, invalidate_cache=invalidate_cache)
         if len(added) > 0 and any(c is false for c in added):
             self._cached_satness = False
         elif self._cached_satness is True:
@@ -40,21 +40,21 @@ class SatCacheMixin:
             self._cached_satness = False
         return new_constraints
 
-    def satisfiable(self, extra_constraints=(), **kwargs):
+    def satisfiable(self, extra_constraints=(), exact=None):
         if self._cached_satness is False:
             return False
         if self._cached_satness is True and len(extra_constraints) == 0:
             return True
-        r = super().satisfiable(extra_constraints=extra_constraints, **kwargs)
+        r = super().satisfiable(extra_constraints=extra_constraints, exact=exact)
         if len(extra_constraints) == 0:
             self._cached_satness = r
         return r
 
-    def eval(self, e, n, extra_constraints=(), **kwargs):
+    def eval(self, e, n, extra_constraints=(), exact=None):
         if self._cached_satness is False:
             raise UnsatError("cached unsat")
         try:
-            r = super().eval(e, n, extra_constraints=extra_constraints, **kwargs)
+            r = super().eval(e, n, extra_constraints=extra_constraints, exact=exact)
             self._cached_satness = True
             return r
         except UnsatError:
@@ -62,11 +62,11 @@ class SatCacheMixin:
                 self._cached_satness = False
             raise
 
-    def batch_eval(self, e, n, extra_constraints=(), **kwargs):
+    def batch_eval(self, e, n, extra_constraints=(), exact=None):
         if self._cached_satness is False:
             raise UnsatError("cached unsat")
         try:
-            r = super().batch_eval(e, n, extra_constraints=extra_constraints, **kwargs)
+            r = super().batch_eval(e, n, extra_constraints=extra_constraints, exact=exact)
             self._cached_satness = True
             return r
         except UnsatError:
@@ -74,11 +74,11 @@ class SatCacheMixin:
                 self._cached_satness = False
             raise
 
-    def max(self, e, extra_constraints=(), **kwargs):
+    def max(self, e, extra_constraints=(), signed=False, exact=None):
         if self._cached_satness is False:
             raise UnsatError("cached unsat")
         try:
-            r = super().max(e, extra_constraints=extra_constraints, **kwargs)
+            r = super().max(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
             self._cached_satness = True
             return r
         except UnsatError:
@@ -86,11 +86,11 @@ class SatCacheMixin:
                 self._cached_satness = False
             raise
 
-    def min(self, e, extra_constraints=(), **kwargs):
+    def min(self, e, extra_constraints=(), signed=False, exact=None):
         if self._cached_satness is False:
             raise UnsatError("cached unsat")
         try:
-            r = super().min(e, extra_constraints=extra_constraints, **kwargs)
+            r = super().min(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
             self._cached_satness = True
             return r
         except UnsatError:
@@ -98,11 +98,11 @@ class SatCacheMixin:
                 self._cached_satness = False
             raise
 
-    def solution(self, e, v, extra_constraints=(), **kwargs):
+    def solution(self, e, v, extra_constraints=(), exact=None):
         if self._cached_satness is False:
             raise UnsatError("cached unsat")
         try:
-            r = super().solution(e, v, extra_constraints=extra_constraints, **kwargs)
+            r = super().solution(e, v, extra_constraints=extra_constraints, exact=exact)
             self._cached_satness = True
             return r
         except UnsatError:

--- a/claripy/frontend_mixins/simplify_helper_mixin.py
+++ b/claripy/frontend_mixins/simplify_helper_mixin.py
@@ -1,18 +1,18 @@
 class SimplifyHelperMixin:
-    def max(self, *args, **kwargs):
+    def max(self, e, extra_constraints=(), signed=False, exact=None):
         self.simplify()
-        return super().max(*args, **kwargs)
+        return super().max(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
 
-    def min(self, *args, **kwargs):
+    def min(self, e, extra_constraints=(), signed=False, exact=None):
         self.simplify()
-        return super().min(*args, **kwargs)
+        return super().min(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
 
-    def eval(self, e, n, *args, **kwargs):
+    def eval(self, e, n, extra_constraints=(), exact=None):
         if n > 1:
             self.simplify()
-        return super().eval(e, n, *args, **kwargs)
+        return super().eval(e, n, extra_constraints=extra_constraints, exact=exact)
 
-    def batch_eval(self, e, n, *args, **kwargs):
+    def batch_eval(self, exprs, n, extra_constraints=(), exact=None):
         if n > 1:
             self.simplify()
-        return super().batch_eval(e, n, *args, **kwargs)
+        return super().batch_eval(exprs, n, extra_constraints=extra_constraints, exact=exact)

--- a/claripy/frontend_mixins/simplify_skipper_mixin.py
+++ b/claripy/frontend_mixins/simplify_skipper_mixin.py
@@ -22,15 +22,15 @@ class SimplifySkipperMixin:
     # Simplification skipping
     #
 
-    def add(self, *args, **kwargs):
-        added = super().add(*args, **kwargs)
+    def add(self, constraints, invalidate_cache=True):
+        added = super().add(constraints, invalidate_cache=invalidate_cache)
         if len(added) > 0:
             self._simplified = False
         return added
 
-    def simplify(self, *args, **kwargs):
+    def simplify(self):
         if self._simplified:
             return self.constraints
         else:
             self._simplified = True
-            return super().simplify(*args, **kwargs)
+            return super().simplify()

--- a/claripy/frontend_mixins/solve_block_mixin.py
+++ b/claripy/frontend_mixins/solve_block_mixin.py
@@ -18,26 +18,26 @@ class SolveBlockMixin:
         self.can_solve, base_state = s
         super().__setstate__(base_state)
 
-    def eval(self, *args, **kwargs):
+    def eval(self, e, n, extra_constraints=(), exact=None):
         assert self.can_solve
-        return super().eval(*args, **kwargs)
+        return super().eval(e.n, extra_constraints=extra_constraints, exact=exact)
 
-    def batch_eval(self, *args, **kwargs):
+    def batch_eval(self, exprs, n, extra_constraints=(), exact=None):
         assert self.can_solve
-        return super().batch_eval(*args, **kwargs)
+        return super().batch_eval(exprs, n, extra_constraints=extra_constraints, exact=exact)
 
-    def min(self, *args, **kwargs):
+    def min(self, e, extra_constraints=(), signed=False, exact=None):
         assert self.can_solve
-        return super().min(*args, **kwargs)
+        return super().min(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
 
-    def max(self, *args, **kwargs):
+    def max(self, e, extra_constraints=(), signed=False, exact=None):
         assert self.can_solve
-        return super().max(*args, **kwargs)
+        return super().max(e, extra_constraints=extra_constraints, signed=signed, exact=exact)
 
-    def satisfiable(self, *args, **kwargs):
+    def satisfiable(self, extra_constraints=(), exact=None):
         assert self.can_solve
-        return super().satisfiable(*args, **kwargs)
+        return super().satisfiable(extra_constraints=extra_constraints, exact=exact)
 
-    def solution(self, *args, **kwargs):
+    def solution(self, e, v, extra_constraints=(), exact=None):
         assert self.can_solve
-        return super().solution(*args, **kwargs)
+        return super().solution(e, v, extra_constraints=extra_constraints, exact=exact)

--- a/claripy/frontend_mixins/solve_block_mixin.py
+++ b/claripy/frontend_mixins/solve_block_mixin.py
@@ -1,4 +1,6 @@
 class SolveBlockMixin:
+    """SolveBlockMixin that adds the ability to block solving by setting can_solve to False."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.can_solve = True
@@ -20,7 +22,7 @@ class SolveBlockMixin:
 
     def eval(self, e, n, extra_constraints=(), exact=None):
         assert self.can_solve
-        return super().eval(e.n, extra_constraints=extra_constraints, exact=exact)
+        return super().eval(e, n, extra_constraints=extra_constraints, exact=exact)
 
     def batch_eval(self, exprs, n, extra_constraints=(), exact=None):
         assert self.can_solve

--- a/claripy/frontends/composite_frontend.py
+++ b/claripy/frontends/composite_frontend.py
@@ -276,7 +276,7 @@ class CompositeFrontend(ConstrainedFrontend):
         self._store_child(s, invalidate_cache=invalidate_cache)
         return added
 
-    def add(self, constraints, **kwargs):  # pylint:disable=arguments-differ
+    def add(self, constraints, invalidate_cache=True):
         split = self._split_constraints(constraints)
         child_added = []
 
@@ -290,7 +290,7 @@ class CompositeFrontend(ConstrainedFrontend):
                 except BackendError:
                     unsure.extend(set_constraints)
             else:
-                child_added += self._add_dependent_constraints(names, set_constraints, **kwargs)
+                child_added += self._add_dependent_constraints(names, set_constraints)
 
         # l.debug("... solvers after add: %d", len(self._solver_list))
 

--- a/claripy/frontends/constrained_frontend.py
+++ b/claripy/frontends/constrained_frontend.py
@@ -98,7 +98,7 @@ class ConstrainedFrontend(Frontend):  # pylint:disable=abstract-method
     # Light functionality
     #
 
-    def add(self, constraints):
+    def add(self, constraints, invalidate_cache=True):
         self.constraints += constraints
         for c in constraints:
             self.variables.update(c.variables)

--- a/claripy/frontends/full_frontend.py
+++ b/claripy/frontends/full_frontend.py
@@ -20,8 +20,6 @@ T = TypeVar("T", bound="FullFrontend")
 
 
 class FullFrontend(ConstrainedFrontend):
-    _model_hook = None
-
     def __init__(self, solver_backend, timeout=None, max_memory=None, track=False, **kwargs):
         ConstrainedFrontend.__init__(self, **kwargs)
         self._track = track
@@ -100,12 +98,12 @@ class FullFrontend(ConstrainedFrontend):
     # Constraint management
     #
 
-    def add(self, constraints: list["Bool"]) -> list["Bool"]:
+    def add(self, constraints, invalidate_cache=True):
         to_add = ConstrainedFrontend.add(self, constraints)
         self._to_add += to_add
         return to_add
 
-    def simplify(self) -> list["Bool"]:
+    def simplify(self):
         ConstrainedFrontend.simplify(self)
 
         # TODO: should we do this?
@@ -336,3 +334,10 @@ class FullFrontend(ConstrainedFrontend):
             self._solver_backend.__class__.__name__ == "BackendZ3",
             ConstrainedFrontend.merge(self, others, merge_conditions, common_ancestor=common_ancestor)[1],
         )
+
+    #
+    # Default model hook
+    #
+
+    def _model_hook(self, m):
+        return None

--- a/claripy/frontends/full_frontend.py
+++ b/claripy/frontends/full_frontend.py
@@ -339,5 +339,5 @@ class FullFrontend(ConstrainedFrontend):
     # Default model hook
     #
 
-    def _model_hook(self, m):
+    def _model_hook(self, m):  # pylint:disable=unused-argument,no-self-use
         return None

--- a/claripy/frontends/hybrid_frontend.py
+++ b/claripy/frontends/hybrid_frontend.py
@@ -128,7 +128,7 @@ class HybridFrontend(Frontend):
     # Lifecycle
     #
 
-    def add(self, constraints):
+    def add(self, constraints, invalidate_cache=True):
         added = self._exact_frontend.add(constraints)
         self._approximate_frontend.add(constraints)
         return added

--- a/claripy/frontends/replacement_frontend.py
+++ b/claripy/frontends/replacement_frontend.py
@@ -260,7 +260,7 @@ class ReplacementFrontend(ConstrainedFrontend):
         else:
             return super()._concrete_constraint(e)
 
-    def add(self, constraints, **kwargs):
+    def add(self, constraints, invalidate_cache=True):
         if self._auto_replace:
             for c in constraints:
                 # the badass thing here would be to use the *replaced* constraint, but
@@ -293,12 +293,12 @@ class ReplacementFrontend(ConstrainedFrontend):
 
                         self.add_replacement(old, rold.intersection(new))
 
-        added = super().add(constraints, **kwargs)
+        added = super().add(constraints)
         cr = self._replace_list(added)
         if not self._allow_symbolic and any(c.symbolic for c in cr):
             raise ClaripyFrontendError(
                 "symbolic constraints made it into ReplacementFrontend with allow_symbolic=False"
             )
-        self._actual_frontend.add(cr, **kwargs)
+        self._actual_frontend.add(cr)
 
         return added


### PR DESCRIPTION
This removes all the *args and **kwargs from the frontends and frontend mixins. This is actually a regression typing wise because I was trying to get mypy to be happy about all of the definitions, and having some methods have type constraints while others didn't prevented that. I will follow up with a PR re-introducing types more uniformly.