### PR TITLE
Remove eager_backends and quick_backends

### DIFF
--- a/claripy/__init__.py
+++ b/claripy/__init__.py
@@ -61,9 +61,9 @@ def BV(name, size, explicit_name=None):  # pylint:disable=function-redefined
 
 from . import backend_manager as _backend_manager
 
-_backend_manager.backends._register_backend(_backends_module.BackendConcrete(), "concrete", True, True)
-_backend_manager.backends._register_backend(_backends_module.BackendVSA(), "vsa", False, False)
-_backend_manager.backends._register_backend(_backends_module.BackendZ3(), "z3", False, False)
+_backend_manager.backends._register_backend(_backends_module.BackendConcrete(), "concrete")
+_backend_manager.backends._register_backend(_backends_module.BackendVSA(), "vsa")
+_backend_manager.backends._register_backend(_backends_module.BackendZ3(), "z3")
 backends = _backend_manager.backends
 
 

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -39,7 +39,7 @@ l = logging.getLogger("claripy.ast")
 md5_unpacker = struct.Struct("2Q")
 from_iterable = chain.from_iterable
 
-# pylint:enable=unused-argument
+# pylint:enable=unused-argument,too-many-boolean-expressions
 
 ArgType = Union["Base", bool, int, float, str, tuple["ArgType"], None]
 # TODO: HashType should be int, but it isn't always int
@@ -1045,7 +1045,7 @@ class Base:
         return True
 
     def replace_dict(
-        self, replacements, variable_set: set[str] | None = None, leaf_operation: Callable[[Base], Base] | None = None
+        self, replacements, variable_set: set[str] | None = None, leaf_operation: Callable[[Base], Base] = lambda x: x
     ) -> Self:
         """
         Returns this AST with subexpressions replaced by those that can be found in `replacements`
@@ -1059,9 +1059,6 @@ class Base:
         """
         if variable_set is None:
             variable_set = set()
-
-        if leaf_operation is None:
-            leaf_operation = lambda x: x
 
         arg_queue = [iter([self])]
         rep_queue = []
@@ -1394,5 +1391,5 @@ def simplify(e: T) -> T:
     return s
 
 
-# pylint:disable=wrong-import-position
+# pylint:disable=wrong-import-position,ungrouped-imports
 from claripy.ast.bool import If, Not  # noqa: E402

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -5,6 +5,7 @@ import logging
 import math
 import struct
 from collections import OrderedDict, deque
+from contextlib import suppress
 from enum import IntEnum
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Generic, NoReturn, TypeVar, Union, cast
@@ -143,7 +144,6 @@ class Base:
     _uneliminatable_annotations: frozenset[Annotation]
 
     # Backend information
-    _eager_backends: list[Backend]
     _errored: set[Backend]
 
     # Caching
@@ -168,7 +168,6 @@ class Base:
         "_simplified",
         "_uneliminatable_annotations",
         "_relocatable_annotations",
-        "_eager_backends",
         "_errored",
         "_cache_key",
         "_cached_encoded_name",
@@ -191,7 +190,6 @@ class Base:
         symbolic: bool | None = None,
         variables: set[str] | None = None,
         errored: set[Backend] | None = None,
-        eager_backends: set[Backend] | None = None,
         uninitialized: bool | None = None,
         uc_alloc_depth: int | None = None,
         annotations: tuple[Annotation, ...] = (),
@@ -214,7 +212,6 @@ class Base:
                                         1 means fast-simplified (basically, just undoing the Reverse
                                         op), and 2 means simplified through z3.
         :param errored:             A set of backends that are known to be unable to handle this AST.
-        :param eager_backends:      A list of backends with which to attempt eager evaluation
         :param annotations:         A frozenset of annotations applied onto this AST.
         """
 
@@ -262,21 +259,11 @@ class Base:
         if add_variables:
             variables = variables | add_variables
 
-        if eager_backends is None:
-            eager_backends = list(backends._eager_backends)
-
         if not symbolic and op not in operations.leaf_operations:
-            for eb in eager_backends:
-                try:
-                    r = operations._handle_annotations(eb._abstract(eb.call(op, args)), args)
-                    if r is not None:
-                        return r
-                    eager_backends.remove(eb)
-                except BackendError:  # noqa: PERF203
-                    eager_backends.remove(eb)
-
-            # if we can't be eager anymore, null out the eagerness
-            eager_backends = None
+            with suppress(BackendError):
+                r = operations._handle_annotations(backends.concrete._abstract(backends.concrete.call(op, args)), args)
+                if r is not None:
+                    return r
 
         # process annotations
         if not annotations and not args_have_annotations:
@@ -356,7 +343,6 @@ class Base:
                 symbolic=symbolic,
                 length=length,
                 errored=errored,
-                eager_backends=eager_backends,
                 uninitialized=uninitialized,
                 uc_alloc_depth=uc_alloc_depth,
                 annotations=annotations,
@@ -513,7 +499,6 @@ class Base:
         length: int | None = None,
         simplified: SimplificationLevel = SimplificationLevel.UNSIMPLIFIED,
         errored: set[Backend] | None = None,
-        eager_backends: set[Backend] | None = None,
         uninitialized: bool | None = None,
         uc_alloc_depth: int | None = None,
         annotations: Iterable[Annotation] | None = None,
@@ -542,7 +527,6 @@ class Base:
 
         self.depth = depth if depth is not None else 1
 
-        self._eager_backends = eager_backends
         self._cached_encoded_name = encoded_name
 
         self._errored = errored if errored is not None else set()
@@ -640,7 +624,6 @@ class Base:
                 annotations=annotations,
                 length=length,
                 uninitialized=self._uninitialized,
-                eager_backends=self._eager_backends,
                 uc_alloc_depth=self.uc_alloc_depth,
             )
 

--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -167,18 +167,16 @@ Bool.__ror__ = Or
 
 
 def is_true(e, exact=None):  # pylint:disable=unused-argument
-    for b in backends._quick_backends:
-        with suppress(BackendError):
-            return b.is_true(e)
+    with suppress(BackendError):
+        return backends.concrete.is_true(e)
 
     l.debug("Unable to tell the truth-value of this expression")
     return False
 
 
 def is_false(e, exact=None):  # pylint:disable=unused-argument
-    for b in backends._quick_backends:
-        with suppress(BackendError):
-            return b.is_false(e)
+    with suppress(BackendError):
+        return backends.concrete.is_false(e)
 
     l.debug("Unable to tell the truth-value of this expression")
     return False

--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -257,7 +257,6 @@ def BVS(
         variables={n},
         length=size,
         symbolic=True,
-        eager_backends=None,
         uninitialized=uninitialized,
         encoded_name=encoded_name,
         **kwargs,

--- a/claripy/ast/strings.py
+++ b/claripy/ast/strings.py
@@ -140,7 +140,6 @@ def StringS(name, size, uninitialized=False, explicit_name=False, **kwargs):
         n,
         length=8 * size,
         symbolic=True,
-        eager_backends=None,
         uninitialized=uninitialized,
         variables={n},
         **kwargs,

--- a/claripy/backend_manager.py
+++ b/claripy/backend_manager.py
@@ -3,21 +3,14 @@ from __future__ import annotations
 
 class BackendManager:
     def __init__(self):
-        self._eager_backends = []
-        self._quick_backends = []
         self._all_backends = []
         self._backends_by_type = {}
         self._backends_by_name = {}
 
-    def _register_backend(self, b, name, eager, quick):
+    def _register_backend(self, b, name):
         self._backends_by_name[name] = b
         self._backends_by_type[b.__class__.__name__] = b
         self._all_backends.append(b)
-        if eager:
-            self._eager_backends.append(b)
-
-        if quick:
-            self._quick_backends.append(b)
 
     def __getattr__(self, a):
         if a in self._backends_by_name:

--- a/claripy/backend_manager.py
+++ b/claripy/backend_manager.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 
 class BackendManager:
+    """BackendManager is a class that manages all backends in claripy. It is a singleton class."""
+
     def __init__(self):
         self._all_backends = []
         self._backends_by_type = {}

--- a/claripy/frontend_mixins/eager_resolution_mixin.py
+++ b/claripy/frontend_mixins/eager_resolution_mixin.py
@@ -15,8 +15,7 @@ class EagerResolutionMixin:
         if r is not None:
             return r
 
-        for b in backends._eager_backends:
-            with suppress(BackendError):
-                return b.eval(e, 1)[0]
+        with suppress(BackendError):
+            return backends.concrete.eval(e, 1)[0]
 
         return None

--- a/claripy/frontends/replacement_frontend.py
+++ b/claripy/frontends/replacement_frontend.py
@@ -243,9 +243,8 @@ class ReplacementFrontend(ConstrainedFrontend):
             return c
 
         cr = self._replacement(e)
-        for b in backends._eager_backends:
-            with suppress(BackendError):
-                return b.eval(cr, 1)[0]
+        with suppress(BackendError):
+            return backends.concrete.eval(cr, 1)[0]
         return None
 
     def _concrete_constraint(self, e):

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -345,17 +345,13 @@ class TestExpression(unittest.TestCase):
         assert claripy.is_true(b_concat == a100)
 
     def test_true_false_cache(self):
-        claripy.backends._quick_backends.append(claripy.backends.z3)
-
         a = claripy.BVS("a_WILL_BE_VIOLATED", 32)
         c = a == a + 1
-        assert claripy.is_false(c)
+        assert claripy.backends.z3.is_false(c)
         c.args[1].args = (a, claripy.BVV(0, 32))
-        assert claripy.is_false(c)
-        assert not claripy.is_true(c)
-        assert not claripy.is_false(a == a)
-
-        claripy.backends._quick_backends[-1:] = []
+        assert claripy.backends.z3.is_false(c)
+        assert not claripy.backends.z3.is_true(c)
+        assert not claripy.backends.z3.is_false(a == a)
 
     def test_depth_repr(self):
         x = claripy.BVS("x", 32)


### PR DESCRIPTION
These are never actually utilized and we want to remove the backend manager anyways. Also removes a handful of pointless loops which are usually just calling the concrete backend.