### PR TITLE
Fix weirdly formatted functions in ModelCache

### DIFF
--- a/claripy/frontend_mixins/model_cache_mixin.py
+++ b/claripy/frontend_mixins/model_cache_mixin.py
@@ -47,34 +47,26 @@ class ModelCache:
     #
 
     def _leaf_op(self, a):
-        return (
-            claripy.BVV(self.model.get(a.args[0], 0), a.length)
-            if a.op == "BVS"
-            else (
-                claripy.BoolV(self.model.get(a.args[0], True))
-                if a.op == "BoolS"
-                else (
-                    claripy.FPV(self.model.get(a.args[0], 0.0), a.args[1])
-                    if a.op == "FPS"
-                    else claripy.StringV(self.model.get(a.args[0], "")) if a.op == "StringS" else a
-                )
-            )
-        )
+        if a.op == "BVS":
+            return claripy.BVV(self.model.get(a.args[0], 0), a.length)
+        if a.op == "BoolS":
+            return claripy.BoolV(self.model.get(a.args[0], True))
+        if a.op == "FPS":
+            return claripy.FPV(self.model.get(a.args[0], 0.0), a.args[1])
+        if a.op == "StringS":
+            return claripy.StringV(self.model.get(a.args[0], ""))
+        return a
 
     def _leaf_op_existonly(self, a):
-        return (
-            claripy.BVV(self.model[a.args[0]], a.length)
-            if a.op == "BVS"
-            else (
-                claripy.BoolV(self.model[a.args[0]])
-                if a.op == "BoolS"
-                else (
-                    claripy.FPV(self.model[a.args[0]], a.args[1])
-                    if a.op == "FPS"
-                    else claripy.StringV(self.model[a.args[0]]) if a.op == "StringS" else a
-                )
-            )
-        )
+        if a.op == "BVS":
+            return claripy.BVV(self.model[a.args[0]], a.length)
+        if a.op == "BoolS":
+            return claripy.BoolV(self.model[a.args[0]])
+        if a.op == "FPS":
+            return claripy.FPV(self.model[a.args[0]], a.args[1])
+        if a.op == "StringS":
+            return claripy.StringV(self.model[a.args[0]])
+        return a
 
     def eval_ast(self, ast, allow_unconstrained: bool = True):
         """


### PR DESCRIPTION
These two functions got rewritten by ruff in a very unappealing way, this rewrites them to be more close to the original while still satisfying the beast. Someday maybe we'll be able to use match statements.