### PR TITLE
Fix AttributeError when calling concrete_value on a Bool

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -1193,7 +1193,10 @@ class Base:
     @property
     def concrete_value(self):
         try:
-            return backends.concrete.convert(self).value
+            raw = backends.concrete.convert(self)
+            if isinstance(raw, bool):
+                return raw
+            return raw.value
         except BackendError:
             return self
 


### PR DESCRIPTION
BackendConcrete will return either a (non-AST) BVV, or a bool. To unpack the BVV into a Python int, it calls `.value`. This fails in the case that it returns a bool, which can be returned directly.