### PR TITLE
Better handle None values in BV

### DIFF
--- a/claripy/bv.py
+++ b/claripy/bv.py
@@ -53,8 +53,10 @@ class BVV(BackendObject):
 
     def __init__(self, value, bits):
         if _d._DEBUG:
-            if bits < 0 or not isinstance(bits, numbers.Number) or not isinstance(value, numbers.Number):
+            if not isinstance(bits, numbers.Number) or bits < 0:
                 raise ClaripyOperationError("BVV needs a non-negative length and an int value")
+            if not isinstance(value, numbers.Number | None):
+                raise ClaripyOperationError("BVV needs a number or None value")
 
             if bits == 0 and value not in (0, "", None):
                 raise ClaripyOperationError("Zero-length BVVs cannot have a meaningful value.")
@@ -81,7 +83,7 @@ class BVV(BackendObject):
 
     @value.setter
     def value(self, v):
-        self._value = v & (self.mod - 1)
+        self._value = v & (self.mod - 1) if v is not None else None
 
     @property
     def signed(self):

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -44,6 +44,12 @@ class TestBv(unittest.TestCase):
         assert -zero == 0
         assert ~zero == 255
 
+    def test_none_value(self):
+        a = claripy.ast.bv.TSI(8)
+        b = claripy.ast.bv.BVV(1, 8)
+        a.union(b)
+        # If we get to this point, the test passed
+
     def test_get_byte(self):
         a = claripy.BVV(0xABCDEF12, 32)
         assert a.get_byte(0).args[0] == 0xAB


### PR DESCRIPTION
`claripy.ESI` makes an `ast.BV` with a value of `None`, the concrete backend trips on this during the union op. This makes it handle it a bit.