### PR TITLE
Add __slots__ to ASTCacheKey

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -41,6 +41,8 @@ T = TypeVar("T", bound="Base")
 class ASTCacheKey(Generic[T]):
     """ASTCacheKey is a wrapper around an AST that is used as a key in caches."""
 
+    __slots__ = ("ast",)
+
     def __init__(self, a: T):
         self.ast: T = a
 

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -41,7 +41,7 @@ T = TypeVar("T", bound="Base")
 class ASTCacheKey(Generic[T]):
     """ASTCacheKey is a wrapper around an AST that is used as a key in caches."""
 
-    __slots__ = ("ast",)
+    __slots__ = ("ast", "__weakref__")
 
     def __init__(self, a: T):
         self.ast: T = a


### PR DESCRIPTION
I might be wrong but I think this might be like 100+ bytes per object, given there is exactly one member? That could actually add up to something.