### PR TITLE
Simplify simplify routines

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -132,6 +132,7 @@ class Base:
     depth: int
     _hash: int
     _simplified: SimplificationLevel
+    _relocatable_annotations: frozenset[Annotation]
     _uneliminatable_annotations: frozenset[Annotation]
 
     # Backend information
@@ -1262,7 +1263,7 @@ class Base:
 
 
 def simplify(e: T) -> T:
-    if isinstance(e, Base) and e.is_leaf():
+    if e.is_leaf() or e._simplified == SimplificationLevel.FULL_SIMPLIFY:
         return e
 
     s = e._first_backend("simplify")
@@ -1272,7 +1273,6 @@ def simplify(e: T) -> T:
 
     # Copy some parameters (that should really go to the Annotation backend)
     s._uninitialized = e.uninitialized
-    s._simplified = SimplificationLevel.FULL_SIMPLIFY
 
     # dealing with annotations
     if e.annotations:

--- a/claripy/backends/backend.py
+++ b/claripy/backends/backend.py
@@ -296,13 +296,10 @@ class Backend:
     # These functions simplify expressions.
     #
 
-    def simplify(self, e):
-        o = self._abstract(self._simplify(self.convert(e)))
-        o._simplified = SimplificationLevel.FULL_SIMPLIFY
-        return o
-
-    def _simplify(self, e):  # pylint:disable=R0201,unused-argument
-        raise BackendError(f"backend {self.__class__.__name__} can't simplify")
+    def simplify(self, expr):
+        result = self._abstract(self.convert(expr))
+        result._simplified = SimplificationLevel.FULL_SIMPLIFY
+        return result
 
     #
     # Some other helpers

--- a/claripy/backends/backend_concrete/backend_concrete.py
+++ b/claripy/backends/backend_concrete/backend_concrete.py
@@ -142,9 +142,6 @@ class BackendConcrete(Backend):
             return r
         raise BackendError(f"can't handle AST of type {type(r)}")
 
-    def _simplify(self, e):
-        return e
-
     def _abstract(self, e):  # pylint:disable=no-self-use
         if isinstance(e, bv.BVV):
             return BVV(e.value, e.size())

--- a/claripy/backends/backend_vsa/backend_vsa.py
+++ b/claripy/backends/backend_vsa/backend_vsa.py
@@ -137,12 +137,6 @@ class BackendVSA(Backend):
             )
         raise BackendError(f"Don't know how to abstract {type(e)}")
 
-    def _simplify(self, e):
-        """This _simplify impementation works because the simplification is done
-        during the conversion from AST to VSA backend objects.
-        """
-        return e
-
     def _eval(self, expr, n, extra_constraints=(), solver=None, model_callback=None):
         if isinstance(expr, StridedInterval | ValueSet):
             return expr.eval(n)


### PR DESCRIPTION
Like other backend methods, there exists a "regular" and underscore-prefixed version of the same method. In the case of simplify, nothing actually uses this. The concrete and vsa backends use the default "just return it" implementation, and z3 overrode the parent simplify and errored on _simplify. So let's just remove the _simplify method to keep this tidier.