### PR TITLE
Change Base.concrete implementation to return `not self.symbolic`

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -1242,14 +1242,7 @@ class Base:
 
     @property
     def concrete(self) -> bool:
-        # fast path
-        if self.op in {"BVV", "BoolV", "FPV"}:
-            return True
-        if self.op in {"BVS", "BoolS", "FPS"}:
-            return False
-        if self.variables:
-            return False
-        return claripy.backends.concrete.handles(self)
+        return not self.symbolic
 
     @property
     def uninitialized(self) -> bool:

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 
 blake2b_unpacker = struct.Struct("Q")
 
-# pylint:disable=unused-argument,too-many-boolean-expressions
+# pylint:disable=unused-argument,too-many-boolean-expressions,too-many-positional-arguments
 
 ArgType = Union["Base", bool, int, float, str, FSort, tuple["ArgType"], None]
 
@@ -140,7 +140,7 @@ class Base:
     _errored: set[Backend]
 
     # Caching
-    _ast_cache_key: ASTCacheKey[Self]
+    _cache_key: ASTCacheKey[Self]
     _cached_encoded_name: bytes | None
 
     # Extra information
@@ -351,7 +351,7 @@ class Base:
 
     # pylint:disable=attribute-defined-outside-init
     def __a_init__(
-        self,
+        self: Self,
         op: str,
         args: tuple[ArgType, ...],
         variables: frozenset[str],


### PR DESCRIPTION
Seems like this should be trivial, and faster than the fastpath