### PR TITLE
Move simplify from base.py to new algorithm sub-package

### DIFF
--- a/claripy/__init__.py
+++ b/claripy/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from claripy import ast
+from claripy import algorithm, ast
+from claripy.algorithm import simplify
 from claripy.annotation import Annotation, RegionAnnotation, SimplificationAvoidanceAnnotation
-from claripy.ast.base import simplify
 from claripy.ast.bool import (
     And,
     BoolS,
@@ -112,6 +112,7 @@ from claripy.solvers import (
 __version__ = "9.2.121.dev0"
 
 __all__ = (
+    "algorithm",
     "Annotation",
     "RegionAnnotation",
     "SimplificationAvoidanceAnnotation",

--- a/claripy/algorithm/__init__.py
+++ b/claripy/algorithm/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .simplify import simplify
+
+__all__ = ("simplify",)

--- a/claripy/algorithm/simplify.py
+++ b/claripy/algorithm/simplify.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from itertools import chain
+from typing import TypeVar
+
+from claripy.ast.base import Base, SimplificationLevel
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=Base)
+
+
+def simplify(expr: T) -> T:
+    """
+    Simplify an expression.
+    """
+
+    if expr.is_leaf() or expr._simplified == SimplificationLevel.FULL_SIMPLIFY:
+        return expr
+
+    simplified = expr._first_backend("simplify")
+    if simplified is None:
+        log.debug("Unable to simplify expression")
+        return expr
+
+    # Copy some parameters (that should really go to the Annotation backend)
+    simplified._uninitialized = expr.uninitialized
+
+    # dealing with annotations
+    if expr.annotations:
+        ast_args = tuple(a for a in expr.args if isinstance(a, Base))
+        annotations = tuple(
+            set(
+                chain(
+                    chain.from_iterable(a._relocatable_annotations for a in ast_args),
+                    tuple(a for a in expr.annotations),
+                )
+            )
+        )
+        if annotations != simplified.annotations:
+            simplified = simplified.remove_annotations(simplified.annotations)
+            simplified = simplified.annotate(*annotations)
+
+    return simplified

--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -1256,32 +1256,3 @@ class Base:
         # TODO: It should definitely be moved to the proposed Annotation backend.
 
         return self._uninitialized
-
-
-def simplify(e: T) -> T:
-    if e.is_leaf() or e._simplified == SimplificationLevel.FULL_SIMPLIFY:
-        return e
-
-    s = e._first_backend("simplify")
-    if s is None:
-        log.debug("Unable to simplify expression")
-        return e
-
-    # Copy some parameters (that should really go to the Annotation backend)
-    s._uninitialized = e.uninitialized
-
-    # dealing with annotations
-    if e.annotations:
-        ast_args = tuple(a for a in e.args if isinstance(a, Base))
-        annotations = tuple(
-            set(
-                chain(
-                    chain.from_iterable(a._relocatable_annotations for a in ast_args), tuple(a for a in e.annotations)
-                )
-            )
-        )
-        if annotations != s.annotations:
-            s = s.remove_annotations(s.annotations)
-            s = s.annotate(*annotations)
-
-    return s

--- a/claripy/frontend/constrained_frontend.py
+++ b/claripy/frontend/constrained_frontend.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 
+from claripy.algorithm import simplify
 from claripy.annotation import SimplificationAvoidanceAnnotation
-from claripy.ast.base import simplify
 from claripy.ast.bool import And, Or
 
 from .frontend import Frontend


### PR DESCRIPTION
The basic plan here is to remove the last backend references in the AST by just moving many of the functions to a new algorithms subpackage. This improve modularization by separating the AST from the various operations that can be preformed on an AST.