### PR TITLE
Allow simplifications to handle annotations

### DIFF
--- a/claripy/ast/base.py
+++ b/claripy/ast/base.py
@@ -246,7 +246,7 @@ class Base:
         length: int | None = None,
     ) -> Self:
         # Try to simplify the expression again
-        simplified = claripy.simplifications.simplify(op, args) if simplify else None
+        simplified, annotated = claripy.simplifications.simplify(op, args) if simplify else (None, False)
         if simplified is not None:
             op = simplified.op
         if (  # fast path
@@ -294,7 +294,10 @@ class Base:
         # special case: if self is one of the args, we do not copy annotations over from self since child
         # annotations will be re-processed during AST creation.
         if annotations is None:
-            annotations = self.annotations if not args or not any(self is arg for arg in args) else ()
+            if not annotated:
+                annotations = self.annotations if not args or not any(self is arg for arg in args) else ()
+            else:
+                annotations = simplified.annotations
         if variables is None and op in all_operations:
             variables = self.variables
         if uninitialized is None:

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -54,9 +54,12 @@ def op(name, arg_types, return_type, extra_check=None, calc_length=None):
                     raise ClaripyOperationError(msg)
 
         # pylint:disable=too-many-nested-blocks
-        simp = _handle_annotations(claripy.simplifications.simplify(name, fixed_args), args)
+        simp, annotated = claripy.simplifications.simplify(name, fixed_args)
         if simp is not None:
-            return simp
+            if not annotated:
+                simp = _handle_annotations(simp, fixed_args)
+            if simp is not None:
+                return simp
 
         kwargs = {}
         if calc_length is not None:
@@ -73,9 +76,6 @@ def op(name, arg_types, return_type, extra_check=None, calc_length=None):
 
 
 def _handle_annotations(simp, args):
-    if simp is None:
-        return None
-
     # pylint:disable=isinstance-second-argument-not-valid-type
     ast_args = tuple(a for a in args if isinstance(a, claripy.ast.Base))
     preserved_relocatable = frozenset(simp._relocatable_annotations)


### PR DESCRIPTION
This is a bunch of nonsense to handle the case where you have an Extract over a Concat where the bounds of the Extract select one of the args of the Concat, but the other arg of the Concat has a relocatable annotation that gets grafted onto the arg being extracted.