### PR TITLE
Remove spurious uninitialized kwargs from tests

### DIFF
--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -58,7 +58,7 @@ class TestSimplify(unittest.TestCase):
 
     def test_rotate_shift_mask_simplification(self):
         a = claripy.BVS("N", 32).annotate(claripy.annotation.StridedIntervalAnnotation(1, 0x1, 0xC))
-        extend_ = claripy.BVS("extend", 32, uninitialized=True)
+        extend_ = claripy.BVS("extend", 32)
         a_ext = extend_.concat(a)
         expr = ((a_ext << 3) | (claripy.LShR(a_ext, 61))) & 0x7FFFFFFF8
         model_vsa = claripy.backends.vsa.convert(expr)

--- a/tests/test_vsa.py
+++ b/tests/test_vsa.py
@@ -580,7 +580,6 @@ class TestVSAOperations(unittest.TestCase):  # pylint: disable=no-member functio
     def test_comparison_si_bvv(self):
         # Comparison between claripy.SI and BVV
         si = claripy.SI(bits=32, stride=1, lower_bound=-0x7F, upper_bound=0x7F)
-        claripy.backends.vsa.convert(si).uninitialized = True
         bvv = claripy.BVV(0x30, 32)
         comp = si < bvv
         assert claripy.backends.vsa.convert(comp).identical(MaybeResult())


### PR DESCRIPTION
These don't do anything