### PR TITLE
Fix passing backend FPV objects to math.isnan and math.isinf

### DIFF
--- a/claripy/backends/backend_concrete/fp.py
+++ b/claripy/backends/backend_concrete/fp.py
@@ -403,11 +403,11 @@ def fpIsNaN(x):
     """
     Checks whether the argument is a floating point NaN.
     """
-    return math.isnan(x)
+    return math.isnan(x.value)
 
 
 def fpIsInf(x):
     """
     Checks whether the argument is a floating point infinity.
     """
-    return math.isinf(x)
+    return math.isinf(x.value)

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -67,6 +67,12 @@ class TestFp(unittest.TestCase):
         assert edd != edd2
         assert edd2 == 0x4237B4C7C0000000
 
+    def test_concrete_isnan(self):
+        assert claripy.FPV(0, claripy.FSORT_FLOAT).isNaN() is claripy.false()
+
+    def test_concrete_isinf(self):
+        assert claripy.FPV(0, claripy.FSORT_FLOAT).isInf() is claripy.false()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/angr/claripy/issues/571, adds two test cases