### PR TITLE
BackendZ3: Bypass integer string conversion limit.

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -130,13 +130,9 @@ def Z3_to_int_str(val):
 
     if isinstance(val, float):
         return str(int(val))
-    elif isinstance(val, bool):
-        if val:
-            return "1"
-        else:
-            return "0"
-    else:
-        return int_to_str_unlimited(val)
+    if isinstance(val, bool):
+        return "1" if val else "0"
+    return int_to_str_unlimited(val)
 
 
 if hasattr(sys, "get_int_max_str_digits"):

--- a/tests/test_z3.py
+++ b/tests/test_z3.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import unittest
+import sys
 
 import claripy
 
@@ -41,6 +42,7 @@ class TestZ3(unittest.TestCase):
         """
 
         s2i = claripy.backends.backend_z3.str_to_int_unlimited
+        CHUNK_SIZE = sys.get_int_max_str_digits() if hasattr(sys, "get_int_max_str_digits") else 640
 
         assert s2i("0") == 0
         assert s2i("1337") == 1337
@@ -51,9 +53,13 @@ class TestZ3(unittest.TestCase):
         assert s2i("1" + "0" * 640 + "1") == 10**641 + 1
         assert s2i("1" + "0" * 8192) == 10**8192
 
+        assert s2i("1" + "0" * (CHUNK_SIZE - 1)) == 10 ** (CHUNK_SIZE - 1)
+        assert s2i("1" + "0" * CHUNK_SIZE) == 10**CHUNK_SIZE
+        assert s2i("1" + "0" * (CHUNK_SIZE + 1)) == 10 ** (CHUNK_SIZE + 1)
+
         assert s2i("-0") == 0
         assert s2i("-1") == -1
-        assert s2i("-1" + "0" * 8192) == -(10**8192)
+        assert s2i("-1" + "0" * CHUNK_SIZE) == -(10**CHUNK_SIZE)
 
     def test_int2str(self):
         """
@@ -61,11 +67,13 @@ class TestZ3(unittest.TestCase):
         """
 
         i2s = claripy.backends.backend_z3.int_to_str_unlimited
+        CHUNK_SIZE = sys.get_int_max_str_digits() if hasattr(sys, "get_int_max_str_digits") else 640
 
         assert i2s(0) == "0"
         assert i2s(-1) == "-1"
         assert i2s(1337) == "1337"
         assert i2s(10**8192) == "1" + "0" * 8192
+        assert i2s(10**CHUNK_SIZE) == "1" + "0" * CHUNK_SIZE
 
     def test_get_long_strings(self):
         # Python 3.11 introduced limits in decimal-to-int conversion. we bypass it by using the str_to_int_unlimited

--- a/tests/test_z3.py
+++ b/tests/test_z3.py
@@ -35,6 +35,50 @@ class TestZ3(unittest.TestCase):
             assert z.min(x, solver=s, extra_constraints=(x >= i,)) == i
             assert z.max(x, solver=s, extra_constraints=(x >= i,)) == range_[1]
 
+    def test_str2int(self):
+        """
+        Test the str_to_int_unlimited function.
+        """
+
+        s2i = claripy.backends.backend_z3.str_to_int_unlimited
+
+        assert s2i("0") == 0
+        assert s2i("1337") == 1337
+        assert s2i("1337133713371337") == 1337133713371337
+        assert s2i("1" + "0" * 639) == 10**639
+        assert s2i("1" + "0" * 640) == 10**640
+        assert s2i("1" + "0" * 641) == 10**641
+        assert s2i("1" + "0" * 640 + "1") == 10**641 + 1
+        assert s2i("1" + "0" * 8192) == 10**8192
+
+        assert s2i("-0") == 0
+        assert s2i("-1") == -1
+        assert s2i("-1" + "0" * 8192) == -(10**8192)
+
+    def test_int2str(self):
+        """
+        Test the int_to_str_unlimited function.
+        """
+
+        i2s = claripy.backends.backend_z3.int_to_str_unlimited
+
+        assert i2s(0) == "0"
+        assert i2s(-1) == "-1"
+        assert i2s(1337) == "1337"
+        assert i2s(10**8192) == "1" + "0" * 8192
+
+    def test_get_long_strings(self):
+        # Python 3.11 introduced limits in decimal-to-int conversion. we bypass it by using the str_to_int_unlimited
+        # method.
+        z3 = claripy.backends.backend_z3
+
+        s = claripy.backends.z3.solver()
+        backend = z3.BackendZ3()
+        x = claripy.BVS("x", 16385 * 8)
+        backend.add(s, [x == 10**16384])
+        d = backend.eval(x, 1, solver=s)
+        assert d == [10**16384]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_z3.py
+++ b/tests/test_z3.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-class-docstring,no-self-use
 from __future__ import annotations
 
-import unittest
 import sys
+import unittest
 
 import claripy
 


### PR DESCRIPTION
CPython 3.11 introduced integer string conversion length limit (see https://docs.python.org/3/library/stdtypes.html#integer-string-conversion-length-limitation). We determined that this security protection does not apply to the threat model that angr would face, and in fact, causes issues when we deal with really long strings and integers. Therefore, we bypass the integer conversion limit in this PR.

We also monkey-patch the Z3 Python binding so that it can accept long integers in constraints.