### PR TITLE
Remove pow op from BVs

### DIFF
--- a/claripy/ast/bv.py
+++ b/claripy/ast/bv.py
@@ -425,10 +425,6 @@ BV.__sub__ = operations.op(
     "__sub__", (BV, BV), BV, extra_check=operations.length_same_check, calc_length=operations.basic_length_calc
 )
 BV.__rsub__ = operations.reversed_op(BV.__sub__)
-BV.__pow__ = operations.op(
-    "__pow__", (BV, BV), BV, extra_check=operations.length_same_check, calc_length=operations.basic_length_calc
-)
-BV.__rpow__ = operations.reversed_op(BV.__pow__)
 BV.__mod__ = operations.op(
     "__mod__", (BV, BV), BV, extra_check=operations.length_same_check, calc_length=operations.basic_length_calc
 )

--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -1456,7 +1456,7 @@ op_map = {
     "Z3_OP_PB_EQ": None,
     "Z3_OP_PB_GE": None,
     "Z3_OP_PB_LE": None,
-    "Z3_OP_POWER": "__pow__",
+    "Z3_OP_POWER": None,
     "Z3_OP_PR_AND_ELIM": None,
     "Z3_OP_PR_APPLY_DEF": None,
     "Z3_OP_PR_ASSERTED": None,

--- a/claripy/operations.py
+++ b/claripy/operations.py
@@ -167,8 +167,6 @@ expression_arithmetic_operations = {
     "__rmul__",
     "__sub__",
     "__rsub__",
-    "__pow__",
-    "__rpow__",
     "__mod__",
     "__rmod__",
     "SDiv",
@@ -333,8 +331,6 @@ opposites = {
     "__rmul__": "__mul__",
     "__sub__": "__rsub__",
     "__rsub__": "__sub__",
-    "__pow__": "__rpow__",
-    "__rpow__": "__pow__",
     "__mod__": "__rmod__",
     "__rmod__": "__mod__",
     "__eq__": "__eq__",
@@ -374,7 +370,6 @@ reversed_ops = {
     "__rmod__": "__mod__",
     "__rmul__": "__mul__",
     "__ror__": "__or__",
-    "__rpow__": "__pow__",
     "__rrshift__": "__rshift__",
     "__rsub__": "__sub__",
     "__rtruediv__": "__truediv__",
@@ -427,7 +422,6 @@ infix = {
     "__mul__": "*",
     "__floordiv__": "/",
     "__truediv__": "/",  # the raw / operator should use integral semantics on bitvectors
-    "__pow__": "**",
     "__mod__": "%",
     "__eq__": "==",
     "__ne__": "!=",
@@ -463,7 +457,6 @@ prefix = {
 
 op_precedence = {  # based on https://en.cppreference.com/w/c/language/operator_precedence
     # precedence: 2
-    "__pow__": 2,
     "Not": 2,
     "__neg__": 2,
     "__invert__": 2,

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -46,7 +46,6 @@ class TestAST(unittest.TestCase):
         assert (x - y).is_leaf() is False
         assert (x // y).is_leaf() is False
         assert (x % y).is_leaf() is False
-        assert (x**y).is_leaf() is False
         assert (x & y).is_leaf() is False
         assert (x | y).is_leaf() is False
         assert (x ^ y).is_leaf() is False


### PR DESCRIPTION
This is a test to see if this is actually used anywhere. It isn't supported in any backends, and smtlib nor z3 supports this op.