### PR TITLE
Correctly handle RotateLeft/Right sizes in Z3 backend

### DIFF
--- a/claripy/backends/backend_z3.py
+++ b/claripy/backends/backend_z3.py
@@ -552,6 +552,10 @@ class BackendZ3(Backend):
         if op_name == "ZeroExt":
             bv_size = z3.Z3_get_decl_int_parameter(ctx, decl, 0)
             return claripy.ZeroExt(bv_size, children[0])
+        if op_name == "RotateLeft":
+            return claripy.RotateLeft(children[0], children[1])
+        if op_name == "RotateRight":
+            return claripy.RotateRight(children[0], children[1])
 
         if op_name == "UNINTERPRETED" and num_args == 0:  # symbolic value
             symbol_name = _z3_decl_name_str(ctx, decl)

--- a/tests/test_z3.py
+++ b/tests/test_z3.py
@@ -111,6 +111,30 @@ class TestZ3(unittest.TestCase):
         sbv2 = claripy.backends.z3.simplify(sbv)
         assert sbv2.length == 32
 
+    def test_abstract_rotate_left(self):
+        """
+        Test abstracting rotate_left
+        """
+
+        x = claripy.BVS("x", 32)
+        y = claripy.BVS("y", 32)
+        r = claripy.RotateLeft(x, y)
+
+        r2 = claripy.backends.z3.simplify(r)
+        assert r2.length == 32
+
+    def test_abstract_rotate_right(self):
+        """
+        Test abstracting rotate_right
+        """
+
+        x = claripy.BVS("x", 32)
+        y = claripy.BVS("y", 32)
+        r = claripy.RotateRight(x, y)
+
+        r2 = claripy.backends.z3.simplify(r)
+        assert r2.length == 32
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #649 