### PR TITLE
Add bool Xor; improve simplification

### DIFF
--- a/claripy/algorithm/replace.py
+++ b/claripy/algorithm/replace.py
@@ -16,6 +16,7 @@ def replace_dict(
     replacements: dict[int, Base],
     variable_set: set[str] | None = None,
     leaf_operation: Callable[[Base], Base] = lambda x: x,
+    simplify: bool = False,
 ) -> Base:
     """
     Returns this AST with subexpressions replaced by those that can be found in `replacements`
@@ -71,7 +72,7 @@ def replace_dict(
 
                 # Check if replacement occurred.
                 if any((a is not b for a, b in zip(ast.args, args, strict=False))):
-                    repl = ast.make_like(ast.op, tuple(args))
+                    repl = ast.make_like(ast.op, tuple(args), simplify=simplify)
                     replacements[ast.hash()] = repl
 
                 rep_queue.append(repl)

--- a/claripy/ast/bool.py
+++ b/claripy/ast/bool.py
@@ -160,12 +160,15 @@ def If(cond, true_value, false_value):
 And = operations.op("And", Bool, Bool)
 Or = operations.op("Or", Bool, Bool)
 Not = operations.op("Not", (Bool,), Bool)
+Xor = operations.op("Xor", (Bool, Bool), Bool)
 
 Bool.__invert__ = Not
 Bool.__and__ = And
 Bool.__rand__ = And
 Bool.__or__ = Or
 Bool.__ror__ = Or
+Bool.__xor__ = Xor
+Bool.__rxor__ = Xor
 
 
 # For large tables, ite_dict that uses a binary search tree instead of a "linear" search tree.

--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -8,6 +8,7 @@ from functools import reduce
 from typing import TYPE_CHECKING
 
 import claripy
+from claripy import operations
 from claripy.fp import FSORT_DOUBLE, FSORT_FLOAT
 
 if TYPE_CHECKING:
@@ -399,8 +400,20 @@ def bv_reverse_simplifier(body):
 
 
 def boolean_and_simplifier(*args):
+    needs_rewrite = False
+    for a in args:
+        if a.op == "BoolV":
+            if not a.args[0]:
+                return claripy.false()
+            needs_rewrite = True
+
+    if needs_rewrite:
+        args = tuple(a for a in args if a.op != "BoolV")
+
     if len(args) == 1:
         return args[0]
+    if len(args) == 0:
+        return claripy.false()
 
     # a == 0 && a == 1  ->  False
     if (
@@ -503,19 +516,20 @@ def boolean_and_simplifier(*args):
 
 
 def boolean_or_simplifier(*args):
-    if len(args) == 1:
-        return args[0]
-
-    new_args = []
+    needs_rewrite = False
     for a in args:
-        if a.is_true():
-            return claripy.true()
-        if not a.is_false():
-            new_args.append(a)
+        if a.op == "BoolV":
+            if a.args[0]:
+                return claripy.true()
+            needs_rewrite = True
 
-    if not new_args:
-        return claripy.false()
-    if len(new_args) < len(args):
+    if needs_rewrite:
+        new_args = tuple(a for a in args if a.op != "BoolV")
+
+        if len(new_args) == 1:
+            return new_args[0]
+        if len(new_args) == 0:
+            return claripy.true()
         return claripy.Or(*new_args)
 
     return _flatten_simplifier("Or", _deduplicate_filter, *args)
@@ -801,6 +815,18 @@ def boolean_not_simplifier(body):
     if body.op == "UGE":
         return claripy.ULT(body.args[0], body.args[1])
 
+    return None
+
+
+def boolean_xor_simplifier(a, b):
+    if a.op == "BoolV":
+        if a.args[0]:
+            return ~b
+        return b
+    if b.op == "BoolV":
+        if b.args[0]:
+            return ~a
+        return a
     return None
 
 
@@ -1156,6 +1182,7 @@ _all_simplifiers = {
     "And": boolean_and_simplifier,
     "Or": boolean_or_simplifier,
     "Not": boolean_not_simplifier,
+    "Xor": boolean_xor_simplifier,
     "Reverse": bv_reverse_simplifier,
     "Extract": extract_simplifier,
     "Concat": concat_simplifier,
@@ -1188,6 +1215,9 @@ def simplify(op, args) -> tuple[Base | None, bool]:
     simplified result if possible, along with a boolean representing whether
     annotations were handled by the simplifier.
     """
+
+    if op in operations.commutative_operations:
+        args = tuple(sorted(args, key=lambda x: x.hash()))
 
     if op not in _all_simplifiers:
         return None, False


### PR DESCRIPTION
- Add option to simplify during replacements
- add `__xor__` to Bool ASTs
- add some trivial simplifiers to And/Or/Xor
- for commutative ops, sort arguments by stable hash during simplification

These were all moderately helpful during a CTF.