### PR TITLE
Improve And/Or boolean simplifiers

### DIFF
--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -399,8 +399,20 @@ def bv_reverse_simplifier(body):
 
 
 def boolean_and_simplifier(*args):
+    needs_rewrite = False
+    for a in args:
+        if a.op == "BoolV":
+            if not a.args[0]:
+                return claripy.false()
+            needs_rewrite = True
+
+    if needs_rewrite:
+        args = tuple(a for a in args if a.op != "BoolV")
+
     if len(args) == 1:
         return args[0]
+    if len(args) == 0:
+        return claripy.true()
 
     # a == 0 && a == 1  ->  False
     if (
@@ -503,19 +515,20 @@ def boolean_and_simplifier(*args):
 
 
 def boolean_or_simplifier(*args):
-    if len(args) == 1:
-        return args[0]
-
-    new_args = []
+    needs_rewrite = False
     for a in args:
-        if a.is_true():
-            return claripy.true()
-        if not a.is_false():
-            new_args.append(a)
+        if a.op == "BoolV":
+            if a.args[0]:
+                return claripy.true()
+            needs_rewrite = True
 
-    if not new_args:
-        return claripy.false()
-    if len(new_args) < len(args):
+    if needs_rewrite:
+        new_args = tuple(a for a in args if a.op != "BoolV")
+
+        if len(new_args) == 1:
+            return new_args[0]
+        if len(new_args) == 0:
+            return claripy.false()
         return claripy.Or(*new_args)
 
     return _flatten_simplifier("Or", _deduplicate_filter, *args)


### PR DESCRIPTION
## Summary

Ports the `boolean_and_simplifier` and `boolean_or_simplifier` improvements from the `feat/better-canonicalization` branch (only the And/Or changes — not the `Xor` operator or commutative canonicalization sorting).

Both simplifiers now short-circuit on concrete `BoolV` operands and strip them in a single pass before falling through to the more expensive structural simplification:

- `And`: returns `false` as soon as any operand is concretely `False`; otherwise strips concrete `True` operands.
- `Or`: returns `true` as soon as any operand is concretely `True`; otherwise strips concrete `False` operands.

The empty-after-filter cases use the correct boolean identities — an `And` whose operands are all `True` simplifies to `True`, and an `Or` whose operands are all `False` simplifies to `False`. (The original source branch had these two cases inverted, which flipped satisfiable constraints to unsat.)

## Testing

Ran the full angr test suite against this branch (editable install): **1951 passed**, 50 skipped, 2 xfailed. The only failure was a flaky native unicorn worker-crash under `pytest-xdist` (`test_longinit_x86_64`) that passes in isolation and is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)