### PR TITLE
Canonicalize commutative operations before simplification

### DIFF
--- a/claripy/simplifications.py
+++ b/claripy/simplifications.py
@@ -8,6 +8,7 @@ from functools import reduce
 from typing import TYPE_CHECKING
 
 import claripy
+from claripy import operations
 from claripy.fp import FSORT_DOUBLE, FSORT_FLOAT
 
 if TYPE_CHECKING:
@@ -1188,6 +1189,9 @@ def simplify(op, args) -> tuple[Base | None, bool]:
     simplified result if possible, along with a boolean representing whether
     annotations were handled by the simplifier.
     """
+
+    if op in operations.commutative_operations:
+        args = tuple(sorted(args, key=lambda x: x.hash()))
 
     if op not in _all_simplifiers:
         return None, False


### PR DESCRIPTION
## Summary

Sorts the arguments of commutative operations by hash in `simplify()` so that expressions differing only in operand order canonicalize to the same AST:

- `x + y` and `y + x` produce the same expression
- `And(a, b)` and `And(b, a)` produce the same expression

This improves expression sharing and simplification hit rates. Ported from the `feat/better-canonicalization` branch (just the commutative-canonicalization change — independent of #725).

## Change

```python
if op in operations.commutative_operations:
    args = tuple(sorted(args, key=lambda x: x.hash()))
```

plus the `from claripy import operations` import.

## Testing

Verified canonicalization behavior locally (`x + y is y + x`, `And(x==1, y==2) is And(y==2, x==1)`). Running the full angr test suite against this branch is in progress; will follow up with results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)