### PR TITLE
Fix StridedIntervalAnnotation.__eq__ upper_bound comparison

### DIFF
--- a/claripy/annotation.py
+++ b/claripy/annotation.py
@@ -99,7 +99,7 @@ class StridedIntervalAnnotation(SimplificationAvoidanceAnnotation):
             isinstance(other, StridedIntervalAnnotation)
             and self.stride == other.stride
             and self.lower_bound == other.lower_bound
-            and self.upper_bound == other
+            and self.upper_bound == other.upper_bound
         )
 
     def __repr__(self):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -201,6 +201,11 @@ class TestAnnotation(unittest.TestCase):
         x3 = claripy.simplify(x0 + x1)
         assert len(x3.annotations) == 1
 
+    def test_strided_interval_annotation_eq(self):
+        si = claripy.annotation.StridedIntervalAnnotation
+        assert si(1, 0, 10) == si(1, 0, 10)
+        assert si(1, 0, 10) != si(1, 0, 20)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`__eq__` compared `self.upper_bound` against `other` instead of `other.upper_bound`, so two StridedIntervalAnnotations differing only in `upper_bound` could compare equal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)